### PR TITLE
fix: usize byte count

### DIFF
--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -348,7 +348,7 @@ pub const fn length_of_length(payload_length: usize) -> usize {
     if payload_length < 56 {
         1
     } else {
-        1 + 8 - payload_length.leading_zeros() as usize / 8
+        1 + (usize::BITS as usize / 8) - payload_length.leading_zeros() as usize / 8
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #1 leading to invalid results on 32-bit targets.

## Solution

Use `usize::BITS` to get actual size of a `usize`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
- [ ] Updated CHANGELOG.md
