### PR TITLE
Add enum example

### DIFF
--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -33,3 +33,8 @@ derive = ["dep:alloy-rlp-derive"]
 
 arrayvec = ["dep:arrayvec"]
 smol_str = ["dep:smol_str"]
+
+[[example]]
+name = "enum"
+crate-type = ["staticlib"]
+path = "../../examples/enum.rs"

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -36,5 +36,4 @@ smol_str = ["dep:smol_str"]
 
 [[example]]
 name = "enum"
-crate-type = ["staticlib"]
 path = "../../examples/enum.rs"

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -3,7 +3,8 @@ use bytes::{Bytes, BytesMut};
 
 /// A type that can be decoded from an RLP blob.
 pub trait Decodable: Sized {
-    /// Decodes the blob into the appropriate type. `buf` must be advanced past the decoded object.
+    /// Decodes the blob into the appropriate type. `buf` must be advanced past
+    /// the decoded object.
     fn decode(buf: &mut &[u8]) -> Result<Self>;
 }
 
@@ -176,17 +177,17 @@ mod std_impl {
 #[inline]
 pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N]> {
     if data.len() > N {
-        return Err(Error::Overflow);
+        return Err(Error::Overflow)
     }
 
     let mut v = [0; N];
 
     if data.is_empty() {
-        return Ok(v);
+        return Ok(v)
     }
 
     if data[0] == 0 {
-        return Err(Error::LeadingZero);
+        return Err(Error::LeadingZero)
     }
 
     // SAFETY: length checked above

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -3,7 +3,7 @@ use bytes::{Bytes, BytesMut};
 
 /// A type that can be decoded from an RLP blob.
 pub trait Decodable: Sized {
-    /// Decode the blob into the appropriate type.
+    /// Decodes the blob into the appropriate type. `buf` must be advanced past the decoded object.
     fn decode(buf: &mut &[u8]) -> Result<Self>;
 }
 
@@ -176,17 +176,17 @@ mod std_impl {
 #[inline]
 pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N]> {
     if data.len() > N {
-        return Err(Error::Overflow)
+        return Err(Error::Overflow);
     }
 
     let mut v = [0; N];
 
     if data.is_empty() {
-        return Ok(v)
+        return Ok(v);
     }
 
     if data[0] == 0 {
-        return Err(Error::LeadingZero)
+        return Err(Error::LeadingZero);
     }
 
     // SAFETY: length checked above

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,0 +1,66 @@
+use alloy_rlp::{encode_list, Decodable, Encodable, Error, Header};
+use bytes::BufMut;
+
+#[derive(Debug, PartialEq)]
+enum FooBar {
+    Foo(u64),
+    Bar(u16, u64),
+}
+
+impl Encodable for FooBar {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Foo(x) => {
+                let enc: [&dyn Encodable; 2] = [&0u8, x];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
+            Self::Bar(x, y) => {
+                let enc: [&dyn Encodable; 3] = [&1u8, x, y];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
+        }
+    }
+}
+
+impl Decodable for FooBar {
+    fn decode(data: &mut &[u8]) -> Result<Self, Error> {
+        let mut payload = Header::decode_bytes(data, true)?;
+        match u8::decode(&mut payload)? {
+            0 => {
+                let foo = Self::Foo(u64::decode(&mut payload)?);
+                Ok(foo)
+            }
+            1 => {
+                let bar = Self::Bar(u16::decode(&mut payload)?, u64::decode(&mut payload)?);
+                Ok(bar)
+            }
+            _ => Err(Error::Custom("unknown type")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rlp::BytesMut;
+
+    fn encode(val: &dyn Encodable) -> BytesMut {
+        let mut out = BytesMut::new();
+        val.encode(&mut out);
+        return out;
+    }
+
+    #[test]
+    fn foo_roundtrip() {
+        let f = FooBar::Foo(42);
+        let out = encode(&f);
+        assert_eq!(Ok(f), FooBar::decode(&mut out.as_ref()));
+    }
+
+    #[test]
+    fn bar_roundtrip() {
+        let b = FooBar::Bar(7, 42);
+        let out = encode(&b);
+        assert_eq!(Ok(b), FooBar::decode(&mut out.as_ref()));
+    }
+}

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,4 +1,4 @@
-use alloy_rlp::{encode_list, Decodable, Encodable, Error, Header};
+use alloy_rlp::{encode, encode_list, Decodable, Encodable, Error, Header};
 use bytes::BufMut;
 
 #[derive(Debug, PartialEq)]
@@ -39,22 +39,14 @@ impl Decodable for FooBar {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_rlp::encode;
+fn main() {
+    let foo = FooBar::Foo(42);
+    let out = encode(&foo);
+    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(foo));
 
-    #[test]
-    fn foo_roundtrip() {
-        let val = FooBar::Foo(42);
-        let out = encode(&val);
-        assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
-    }
+    let bar = FooBar::Bar(7, 42);
+    let out = encode(&bar);
+    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(bar));
 
-    #[test]
-    fn bar_roundtrip() {
-        let val = FooBar::Bar(7, 42);
-        let out = encode(&val);
-        assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
-    }
+    println!("success!")
 }

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -26,27 +26,24 @@ impl Decodable for FooBar {
     fn decode(data: &mut &[u8]) -> Result<Self, Error> {
         let mut payload = Header::decode_bytes(data, true)?;
         match u8::decode(&mut payload)? {
-            0 => {
-                let foo = Self::Foo(u64::decode(&mut payload)?);
-                Ok(foo)
-            }
-            1 => {
-                let bar = Self::Bar(u16::decode(&mut payload)?, u64::decode(&mut payload)?);
-                Ok(bar)
-            }
+            0 => Ok(Self::Foo(u64::decode(&mut payload)?)),
+            1 => Ok(Self::Bar(
+                u16::decode(&mut payload)?,
+                u64::decode(&mut payload)?,
+            )),
             _ => Err(Error::Custom("unknown type")),
         }
     }
 }
 
 fn main() {
-    let foo = FooBar::Foo(42);
-    let out = encode(&foo);
-    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(foo));
+    let val = FooBar::Foo(42);
+    let out = encode(&val);
+    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
 
-    let bar = FooBar::Bar(7, 42);
-    let out = encode(&bar);
-    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(bar));
+    let val = FooBar::Bar(7, 42);
+    let out = encode(&val);
+    assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
 
     println!("success!")
 }

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -47,7 +47,7 @@ mod tests {
     fn encode(val: &dyn Encodable) -> BytesMut {
         let mut out = BytesMut::new();
         val.encode(&mut out);
-        return out;
+        return out
     }
 
     #[test]

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -42,25 +42,19 @@ impl Decodable for FooBar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_rlp::BytesMut;
-
-    fn encode(val: &dyn Encodable) -> BytesMut {
-        let mut out = BytesMut::new();
-        val.encode(&mut out);
-        return out
-    }
+    use alloy_rlp::encode;
 
     #[test]
     fn foo_roundtrip() {
-        let f = FooBar::Foo(42);
-        let out = encode(&f);
-        assert_eq!(Ok(f), FooBar::decode(&mut out.as_ref()));
+        let val = FooBar::Foo(42);
+        let out = encode(&val);
+        assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
     }
 
     #[test]
     fn bar_roundtrip() {
-        let b = FooBar::Bar(7, 42);
-        let out = encode(&b);
-        assert_eq!(Ok(b), FooBar::decode(&mut out.as_ref()));
+        let val = FooBar::Bar(7, 42);
+        let out = encode(&val);
+        assert_eq!(FooBar::decode(&mut out.as_ref()), Ok(val));
     }
 }


### PR DESCRIPTION
Spent some time with @ralexstokes and @echoalice trying to debug an issue in a custom encoder / decoder for an enum type. We ultimately realized that `data` needs to be advanced and were using `Rlp` to stream decode (which doesn't advance `data`). In retrospect this makes sense, but in the moment it isn't super clear.

I wanted to add a clarification to the documentation to mention this. Also thought it might be useful to have an enum example since we (mostly Alex) figured out how it might look!