### PR TITLE
fix: `Ip{,v4,v6}Addr::decode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Ip{,v4,v6}Addr::decode` ([#6])
+
+[#6]: https://github.com/alloy-rs/rlp/pull/6
+
 ## [0.3.2] - 2023-07-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
 
+hex = { package = "const-hex", version = "1", default-features = false, features = ["alloc"] }
 hex-literal = "0.4"
 
 # misc

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -24,6 +24,7 @@ arrayvec = { workspace = true, optional = true }
 smol_str = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
+hex.workspace = true
 hex-literal.workspace = true
 
 [features]

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -222,7 +222,7 @@ mod tests {
                 assert_eq!(crate::encode(expected), input, "{expected:?}");
             }
 
-            let orig = &*input;
+            let orig = input;
             assert_eq!(
                 T::decode(&mut input),
                 expected,

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -199,6 +199,7 @@ pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N]> {
     Ok(v)
 }
 
+#[cfg(feature = "std")]
 #[inline]
 fn slice_to_array<const N: usize>(slice: &[u8]) -> Result<[u8; N]> {
     slice.try_into().map_err(|_| Error::UnexpectedLength)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ip addr decoding used `static_left_pad`, which fails if the buffer starts with a zero. This is incorrect and it also should not pad lower lengths

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `<[u8; N]>::try_from(&[u8])`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
- [x] Updated CHANGELOG.md
