### PR TITLE
feat: extract structured payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `decode_raw` static methods to `Header`
+
 ## [0.3.5] - 2024-05-22
 
 ### Changed

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -186,7 +186,7 @@ mod tests {
     use crate::Encodable;
     use core::fmt::Debug;
 
-    fn check_decode_list<T: Encodable + Debug>(input: Vec<T>) {
+    fn check_decode_raw_list<T: Encodable + Debug>(input: Vec<T>) {
         let encoded = crate::encode(&input);
         let expected: Vec<_> = input.iter().map(crate::encode).collect();
         let mut buf = encoded.as_slice();
@@ -199,7 +199,7 @@ mod tests {
         assert!(buf.is_empty(), "buffer was not advanced");
     }
 
-    fn check_decode_string(input: &str) {
+    fn check_decode_raw_string(input: &str) {
         let encoded = crate::encode(input);
         let expected = Header::decode_bytes(&mut &encoded[..], false).unwrap();
         let mut buf = encoded.as_slice();
@@ -215,23 +215,23 @@ mod tests {
     #[test]
     fn decode_raw() {
         // empty list
-        check_decode_list(Vec::<u64>::new());
+        check_decode_raw_list(Vec::<u64>::new());
         // list of an empty RLP list
-        check_decode_list(vec![Vec::<u64>::new()]);
+        check_decode_raw_list(vec![Vec::<u64>::new()]);
         // list of an empty RLP string
-        check_decode_list(vec![""]);
+        check_decode_raw_list(vec![""]);
         // list of two RLP strings
-        check_decode_list(vec![0xBBCCB5_u64, 0xFFC0B5_u64]);
+        check_decode_raw_list(vec![0xBBCCB5_u64, 0xFFC0B5_u64]);
         // list of three RLP lists of various lengths
-        check_decode_list(vec![vec![0u64], vec![1u64, 2u64], vec![3u64, 4u64, 5u64]]);
+        check_decode_raw_list(vec![vec![0u64], vec![1u64, 2u64], vec![3u64, 4u64, 5u64]]);
         // list of four empty RLP strings
-        check_decode_list(vec![0u64; 4]);
+        check_decode_raw_list(vec![0u64; 4]);
         // list of all one-byte strings, some will have an RLP header and some won't
-        check_decode_list((0u64..0xFF).collect());
+        check_decode_raw_list((0u64..0xFF).collect());
 
         // strings of various lengths
-        check_decode_string("");
-        check_decode_string(" ");
-        check_decode_string("test1234");
+        check_decode_raw_string("");
+        check_decode_raw_string(" ");
+        check_decode_raw_string("test1234");
     }
 }

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -205,7 +205,7 @@ mod tests {
         let mut buf = encoded.as_slice();
         assert!(
             matches!(Header::decode_raw(&mut buf), Ok(PayloadView::String(v)) if v == expected),
-            "input: {}, expected list: {:?}",
+            "input: {}, expected string: {:?}",
             input,
             expected
         );

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -184,6 +184,7 @@ fn get_next_byte(buf: &[u8]) -> Result<u8> {
 mod tests {
     use super::*;
     use crate::Encodable;
+    use alloc::vec::Vec;
     use core::fmt::Debug;
 
     fn check_decode_raw_list<T: Encodable + Debug>(input: Vec<T>) {

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -167,7 +167,7 @@ impl Header {
 /// Structured representation of an RLP payload.
 pub enum PayloadView<'a> {
     String(&'a [u8]),
-    List(Vec<&'a [u8]>),
+    List(alloc::vec::Vec<&'a [u8]>),
 }
 
 /// Same as `buf.first().ok_or(Error::InputTooShort)`.


### PR DESCRIPTION
## Motivation

For certain use cases, like MPT nodes, the type of an RLP payload is not known in advance, but depends on its structure.
This PR adds functionality that extracts the payload structure without having to specify its type.
This fixes #17.

## Solution

This PR adds `Header::decode_raw` for this, which returns the following typed enum, that can then be used to determine the payload components and then recursively decode them:
```rust
pub enum PayloadView<'a> {
    String(&'a [u8]),
    List(Vec<&'a [u8]>),
}
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
- [x] Updated CHANGELOG.md
