### PR TITLE
chore: fix `RlpEncodableWrapper` documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix `RlpEncodableWrapper` doc
+- Fix `RlpEncodableWrapper` doc ([#22])
+
+[#22]: https://github.com/alloy-rs/rlp/pull/22
 
 ## [0.3.7] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix `RlpEncodableWrapper` doc
+
 ## [0.3.7] - 2024-06-29
 
 ### Fixed

--- a/crates/rlp-derive/src/lib.rs
+++ b/crates/rlp-derive/src/lib.rs
@@ -27,8 +27,8 @@ pub fn encodable(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derives `Encodable` for the type which encodes the fields as-is, without a
-/// header: `<fields...>`
+/// Derives `Encodable` for the `newtype` which encodes its single field as-is, without a header:
+/// `<field>`
 #[proc_macro_derive(RlpEncodableWrapper, attributes(rlp))]
 pub fn encodable_wrapper(input: TokenStream) -> TokenStream {
     syn::parse(input)


### PR DESCRIPTION
This fixes #12 by simply changing the documentation as suggested by @Rjected. 