### PR TITLE
feat: add function to decode an entire slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `decode_exact` function ([#23])
+
+### Fixed
+
 - Fix `RlpEncodableWrapper` doc ([#22])
 
 [#22]: https://github.com/alloy-rs/rlp/pull/22
+[#23]: https://github.com/alloy-rs/rlp/pull/23
 
 ## [0.3.7] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `decode_full` function
+- `decode_full` function ([#23])
+
+[#23]: https://github.com/alloy-rs/rlp/pull/23
 
 ## [0.3.7] - 2024-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `decode_full` function
+
 ## [0.3.7] - 2024-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `decode_full` function ([#23])
-
-[#23]: https://github.com/alloy-rs/rlp/pull/23
-
 ## [0.3.7] - 2024-06-29
 
 ### Fixed

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -365,15 +365,18 @@ mod tests {
 
     #[test]
     fn rlp_full() {
-        fn check_decode_full<T: Decodable + Encodable + PartialEq + Debug>(input: T) {
+        fn check_decode_exact<T: Decodable + Encodable + PartialEq + Debug>(input: T) {
             let encoded = encode(&input);
-            assert_eq!(decode_full::<T>(&encoded), Ok(input));
-            assert_eq!(decode_full::<T>([encoded, vec![0x00]].concat()), Err(Error::TrailingBytes));
+            assert_eq!(decode_exact::<T>(&encoded), Ok(input));
+            assert_eq!(
+                decode_exact::<T>([encoded, vec![0x00]].concat()),
+                Err(Error::TrailingBytes)
+            );
         }
 
-        check_decode_full::<String>("".into());
-        check_decode_full::<String>("test1234".into());
-        check_decode_full::<Vec<u64>>(vec![]);
-        check_decode_full::<Vec<u64>>(vec![0; 4]);
+        check_decode_exact::<String>("".into());
+        check_decode_exact::<String>("test1234".into());
+        check_decode_exact::<Vec<u64>>(vec![]);
+        check_decode_exact::<Vec<u64>>(vec![0; 4]);
     }
 }

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -182,7 +182,7 @@ mod std_impl {
 ///
 /// Returns an error if the encoding is invalid or if data remains after decoding the RLP item.
 #[inline]
-pub fn decode_full<T: Decodable>(bytes: impl AsRef<[u8]>) -> Result<T> {
+pub fn decode_exact<T: Decodable>(bytes: impl AsRef<[u8]>) -> Result<T> {
     let mut buf = bytes.as_ref();
     let out = T::decode(&mut buf)?;
 

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -188,7 +188,8 @@ pub fn decode_exact<T: Decodable>(bytes: impl AsRef<[u8]>) -> Result<T> {
 
     // check if there are any remaining bytes after decoding
     if !buf.is_empty() {
-        return Err(Error::TrailingBytes);
+        // TODO: introduce a new variant TrailingBytes to better distinguish this error
+        return Err(Error::UnexpectedLength);
     }
 
     Ok(out)
@@ -382,7 +383,7 @@ mod tests {
             assert_eq!(decode_exact::<T>(&encoded), Ok(input));
             assert_eq!(
                 decode_exact::<T>([encoded, vec![0x00]].concat()),
-                Err(Error::TrailingBytes)
+                Err(Error::UnexpectedLength)
             );
         }
 

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -229,7 +229,7 @@ fn slice_to_array<const N: usize>(slice: &[u8]) -> Result<[u8; N]> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Encodable;
+    use crate::{encode, Encodable};
     use core::fmt::Debug;
     use hex_literal::hex;
 
@@ -361,5 +361,19 @@ mod tests {
         ]);
         check_decode::<u8, _>([(Err(Error::InputTooShort), &hex!("82")[..])]);
         check_decode::<u64, _>([(Err(Error::InputTooShort), &hex!("82")[..])]);
+    }
+
+    #[test]
+    fn rlp_full() {
+        fn check_decode_full<T: Decodable + Encodable + PartialEq + Debug>(input: T) {
+            let encoded = encode(&input);
+            assert_eq!(decode_full::<T>(&encoded), Ok(input));
+            assert_eq!(decode_full::<T>([encoded, vec![0x00]].concat()), Err(Error::TrailingBytes));
+        }
+
+        check_decode_full::<String>("".into());
+        check_decode_full::<String>("test1234".into());
+        check_decode_full::<Vec<u64>>(vec![]);
+        check_decode_full::<Vec<u64>>(vec![0; 4]);
     }
 }

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -176,6 +176,24 @@ mod std_impl {
     }
 }
 
+/// Decodes the entire input, ensuring no trailing bytes remain.
+///
+/// # Errors
+///
+/// Returns an error if the encoding is invalid or if data remains after decoding the RLP item.
+#[inline]
+pub fn decode_full<T: Decodable>(bytes: impl AsRef<[u8]>) -> Result<T> {
+    let mut buf = bytes.as_ref();
+    let out = T::decode(&mut buf)?;
+
+    // check if there are any remaining bytes after decoding
+    if !buf.is_empty() {
+        return Err(Error::TrailingBytes);
+    }
+
+    Ok(out)
+}
+
 /// Left-pads a slice to a statically known size array.
 ///
 /// # Errors

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -12,8 +12,6 @@ pub enum Error {
     LeadingZero,
     /// Overran input while decoding.
     InputTooShort,
-    /// Additional trailing bytes found after decoding.
-    TrailingBytes,
     /// Expected single byte, but got invalid value.
     NonCanonicalSingleByte,
     /// Expected size, but got invalid value.
@@ -44,7 +42,6 @@ impl fmt::Display for Error {
             Self::Overflow => f.write_str("overflow"),
             Self::LeadingZero => f.write_str("leading zero"),
             Self::InputTooShort => f.write_str("input too short"),
-            Self::TrailingBytes => f.write_str("trailing bytes"),
             Self::NonCanonicalSingleByte => f.write_str("non-canonical single byte"),
             Self::NonCanonicalSize => f.write_str("non-canonical size"),
             Self::UnexpectedLength => f.write_str("unexpected length"),

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     LeadingZero,
     /// Overran input while decoding.
     InputTooShort,
+    /// Additional trailing bytes found after decoding.
+    TrailingBytes,
     /// Expected single byte, but got invalid value.
     NonCanonicalSingleByte,
     /// Expected size, but got invalid value.
@@ -42,6 +44,7 @@ impl fmt::Display for Error {
             Self::Overflow => f.write_str("overflow"),
             Self::LeadingZero => f.write_str("leading zero"),
             Self::InputTooShort => f.write_str("input too short"),
+            Self::TrailingBytes => f.write_str("trailing bytes"),
             Self::NonCanonicalSingleByte => f.write_str("non-canonical single byte"),
             Self::NonCanonicalSize => f.write_str("non-canonical size"),
             Self::UnexpectedLength => f.write_str("unexpected length"),

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -19,7 +19,7 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{Decodable, Rlp};
+pub use decode::{decode_full, Decodable, Rlp};
 
 mod error;
 pub use error::{Error, Result};

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -19,7 +19,7 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{decode_full, Decodable, Rlp};
+pub use decode::{decode_exact, Decodable, Rlp};
 
 mod error;
 pub use error::{Error, Result};


### PR DESCRIPTION
This PR fixes #21 by adding the public function `decode_exact` described above. It also introduces a new error type, since none of the existing ones fit.
This PR can be closed without merging if the `decode_exact` function is deemed unnecessary in the context of this crate. 

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
- [ ] Updated CHANGELOG.md
