### PR TITLE
chore: clippy

### DIFF
--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "derive")]
+#![allow(dead_code)]
 
 use alloy_rlp::*;
 


### PR DESCRIPTION
Fix clippy warnings with latest nightly:
- Allow dead code in `derive` tests