### PR TITLE
feat: length_with_payload

### DIFF
--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -158,6 +158,11 @@ impl Header {
     pub const fn length(&self) -> usize {
         crate::length_of_length(self.payload_length)
     }
+
+    /// Returns the total length of the encoded header and payload.
+    pub const fn length_with_payload(&self) -> usize {
+        self.length() + self.payload_length
+    }
 }
 
 /// Structured representation of an RLP payload.


### PR DESCRIPTION
Adds a convenience function to `Header` to return the total length with the payload

## Motivation

Seemed useful

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
- [ ] Updated CHANGELOG.md
