### PR TITLE
this should allow dynamic encoding  of Encodables types instead of fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `encode_list_dynamic` which allows to encode a vector of Encodables irregardless of their size
+- `encode_list_dynamic` which allows to encode a vector of Encodables irregardless of their size ([#36])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `encode_list_dynamic` which allows to encode a vector of Encodables irregardless of their size
+
 ### Changed
 
 - Improve `decode_raw` performance ([#34])


### PR DESCRIPTION
This PR is to add a function to gap that you cannot encode a vec of Encodable because encode_list forces all elements to be the same Size.

## Motivation

This can help encoding different types as a list.

## Solution

making another method 

```encode_list_dynamic``` that takes a Vec:<Box<Encodable>> that dosen't enforce the same Size of T like encode_list.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
- [x] Updated CHANGELOG.md
