### PR TITLE
feat: support riscv32im-unknown-none-elf

### DIFF
--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -129,6 +129,7 @@ wrap_impl! {
     [const N: usize] <arrayvec::ArrayVec<u8, N>>::from([u8; N]),
     [T: Decodable] <alloc::boxed::Box<T>>::new(T),
     [T: Decodable] <alloc::rc::Rc<T>>::new(T),
+    #[cfg(target_has_atomic = "ptr")]
     [T: Decodable] <alloc::sync::Arc<T>>::new(T),
 }
 

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -234,6 +234,7 @@ deref_impl! {
     [T: ?Sized + Encodable] alloc::boxed::Box<T>,
     [T: ?Sized + alloc::borrow::ToOwned + Encodable] alloc::borrow::Cow<'_, T>,
     [T: ?Sized + Encodable] alloc::rc::Rc<T>,
+    #[cfg(target_has_atomic = "ptr")]
     [T: ?Sized + Encodable] alloc::sync::Arc<T>,
 }
 


### PR DESCRIPTION
Use alloc::sync::Arc only when target_has_atomic is "ptr".

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently, `alloc::sync::Arc` is enabled based on the target_has_atomic property. However, for the riscv32im-unknown-none-elf target, this property is not set, causing Arc to be unavailable even though other parts of the allocation library may still be useful.

This change ensures that Arc is only enabled when `target_has_atomic = "ptr"`, making the behavior more consistent across architectures and preventing unintended dependencies on atomic operations.

## Solution
The solution involves updating the conditional compilation directive to explicitly check for `target_has_atomic = "ptr"` when using alloc::sync::Arc.
```rust
#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
pub mod sync;
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
- [ ] Updated CHANGELOG.md
