### PR TITLE
feat: implement tuple trait impls and flatten field attribute

### DIFF
--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -8,13 +9,24 @@ use syn::{Error, Result};
 pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let body = parse_struct(ast, "RlpDecodable")?;
 
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_decodable_transparent(ast, body);
+    }
+
     let fields = body.fields.iter().enumerate();
 
     let supports_trailing_opt = attributes_include(&ast.attrs, "trailing");
 
     let mut encountered_opt_item = false;
     let mut decode_stmts = Vec::with_capacity(body.fields.len());
+    let mut decode_stmts_raw = Vec::with_capacity(body.fields.len());
     for (i, field) in fields {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -29,6 +41,7 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
         }
 
         decode_stmts.push(decodable_field(i, field, is_opt));
+        decode_stmts_raw.push(decodable_field_raw(i, field));
     }
 
     let name = &ast.ident;
@@ -44,12 +57,12 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
                     let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(b)?;
                     if !list {
-                        return Err(alloy_rlp::ErrorKind::UnexpectedString);
+                        return Err(alloy_rlp::ErrorKind::UnexpectedString.into());
                     }
 
                     let started_len = b.len();
                     if started_len < payload_length {
-                        return Err(alloy_rlp::ErrorKind::InputTooShort);
+                        return Err(alloy_rlp::ErrorKind::InputTooShort.into());
                     }
 
                     let this = Self {
@@ -61,10 +74,72 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                         return Err(alloy_rlp::ErrorKind::ListLengthMismatch {
                             expected: payload_length,
                             got: consumed,
-                        });
+                        }.into());
                     }
 
                     Ok(this)
+                }
+
+                #[inline]
+                fn rlp_decode_raw(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    Ok(Self {
+                        #(#decode_stmts_raw)*
+                    })
+                }
+            }
+        };
+    })
+}
+
+fn impl_decodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| {
+            !attributes_include(&field.attrs, "skip")
+                && !attributes_include(&field.attrs, "default")
+        })
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped, non-default field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let field_inits: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let ident = field_ident(i, field);
+            if attributes_include(&field.attrs, "skip")
+                || attributes_include(&field.attrs, "default")
+            {
+                quote! { #ident: alloy_rlp::private::Default::default(), }
+            } else {
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(buf)?, }
+            }
+        })
+        .collect();
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::Ok(Self {
+                        #(#field_inits)*
+                    })
                 }
             }
         };
@@ -115,7 +190,116 @@ fn decodable_field(index: usize, field: &syn::Field, is_opt: bool) -> TokenStrea
                 None
             },
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
     } else {
         quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
     }
+}
+
+fn decodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
+        quote! { #ident: alloy_rlp::private::Default::default(), }
+    } else if is_optional(field) {
+        quote! {
+            #ident: if !b.is_empty() {
+                if alloy_rlp::private::Option::map_or(b.first(), false, |x| *x == #EMPTY_STRING_CODE) {
+                    alloy_rlp::Buf::advance(b, 1);
+                    None
+                } else {
+                    Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
+                }
+            } else {
+                None
+            },
+        }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
+    } else {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
+    }
+}
+
+pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpDecodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+
+        let tag_expr: TokenStream = get_tag_value(&variant.attrs).map_or_else(
+            || {
+                variant.discriminant.as_ref().map_or_else(
+                    || {
+                        let idx = i as u8;
+                        quote! { #idx }
+                    },
+                    |(_, expr)| quote! { #expr },
+                )
+            },
+            |expr| quote! { #expr },
+        );
+
+        let construct = match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_decodes: Vec<_> = fields
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let fname = f.ident.as_ref().unwrap();
+                        quote! { #fname: alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? }
+                    })
+                    .collect();
+                quote! { #name::#var_ident { #(#field_decodes),* } }
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_decodes: Vec<_> = (0..fields.unnamed.len())
+                    .map(|_| {
+                        quote! { alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? }
+                    })
+                    .collect();
+                quote! { #name::#var_ident(#(#field_decodes),*) }
+            }
+            syn::Fields::Unit => {
+                quote! { #name::#var_ident }
+            }
+        };
+
+        match_arms.push(quote! {
+            #tag_expr => Ok(#construct),
+        });
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    let mut payload = alloy_rlp::Header::decode_bytes(b, true)?;
+                    let tag = <u8 as alloy_rlp::RlpDecodable>::rlp_decode(&mut payload)?;
+                    let result: alloy_rlp::Result<Self> = match tag {
+                        #(#match_arms)*
+                        _ => Err(alloy_rlp::ErrorKind::Custom("unknown variant tag").into()),
+                    };
+                    let value = result?;
+                    if !payload.is_empty() {
+                        return Err(alloy_rlp::ErrorKind::ListLengthMismatch {
+                            expected: 0,
+                            got: payload.len(),
+                        }.into());
+                    }
+                    Ok(value)
+                }
+            }
+        };
+    })
 }

--- a/crates/rlp-derive/src/en.rs
+++ b/crates/rlp-derive/src/en.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -8,6 +9,10 @@ use syn::{Error, Result};
 
 pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let body = parse_struct(ast, "RlpEncodable")?;
+
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_encodable_transparent(ast, body);
+    }
 
     let mut fields = body
         .fields
@@ -23,6 +28,12 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let mut encode_exprs = Vec::with_capacity(body.fields.len());
 
     while let Some((i, field)) = fields.next() {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -63,6 +74,16 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                     .encode(out);
                     #(#encode_exprs)*
                 }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    self._alloy_rlp_payload_length()
+                }
+
+                #[inline]
+                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    #(#encode_exprs)*
+                }
             }
 
             impl #impl_generics #name #ty_generics #where_clause {
@@ -70,6 +91,48 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 #[inline]
                 fn _alloy_rlp_payload_length(&self) -> usize {
                     0usize #( + #length_exprs)*
+                }
+            }
+        };
+    })
+}
+
+fn impl_encodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let (index, field) = non_skipped[0];
+    let ident = field_ident(index, field);
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out)
                 }
             }
         };
@@ -175,6 +238,8 @@ fn encodable_length<'a>(
         };
 
         quote! { self.#ident.as_ref().map(|val| alloy_rlp::RlpEncodable::rlp_len(val)).unwrap_or(#default) }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
     }
@@ -206,6 +271,8 @@ fn encodable_field<'a>(
         } else {
             quote! { #if_some_encode }
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
     }
@@ -219,4 +286,131 @@ fn remaining_opt_fields_some_condition<'a>(
         quote! { self.#ident.is_some() }
     });
     quote! { #(#conditions)||* }
+}
+
+pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpEncodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut length_arms = Vec::new();
+    let mut encode_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+
+        let tag_expr: TokenStream = get_tag_value(&variant.attrs).map_or_else(
+            || {
+                variant.discriminant.as_ref().map_or_else(
+                    || {
+                        let idx = i as u8;
+                        quote! { #idx }
+                    },
+                    |(_, expr)| quote! { #expr },
+                )
+            },
+            |expr| quote! { #expr },
+        );
+
+        match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_names: Vec<_> =
+                    fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+
+                let length_fields = field_names.iter().map(|f| {
+                    quote! { alloy_rlp::RlpEncodable::rlp_len(#f) }
+                });
+                let encode_fields = field_names.iter().map(|f| {
+                    quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); }
+                });
+
+                length_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|j| syn::Ident::new(&format!("f{j}"), var_ident.span()))
+                    .collect();
+
+                let length_fields = field_names.iter().map(|f| {
+                    quote! { alloy_rlp::RlpEncodable::rlp_len(#f) }
+                });
+                let encode_fields = field_names.iter().map(|f| {
+                    quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); }
+                });
+
+                length_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unit => {
+                length_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag)
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u8 = #tag_expr;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    payload_length + alloy_rlp::length_of_length(payload_length)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    alloy_rlp::Header {
+                        list: true,
+                        payload_length,
+                    }
+                    .encode(out);
+                    match self {
+                        #(#encode_arms)*
+                    }
+                }
+            }
+        };
+    })
 }

--- a/crates/rlp-derive/src/utils.rs
+++ b/crates/rlp-derive/src/utils.rs
@@ -62,10 +62,7 @@ pub(crate) fn field_ident(index: usize, field: &syn::Field) -> TokenStream {
     )
 }
 
-pub(crate) fn parse_enum<'a>(
-    ast: &'a syn::DeriveInput,
-    derive_attr: &str,
-) -> Result<&'a DataEnum> {
+pub(crate) fn parse_enum<'a>(ast: &'a syn::DeriveInput, derive_attr: &str) -> Result<&'a DataEnum> {
     if let syn::Data::Enum(e) = &ast.data {
         Ok(e)
     } else {

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -45,3 +45,8 @@ arrayvec = ["dep:arrayvec"]
 [[example]]
 name = "enum"
 path = "../../examples/enum.rs"
+
+[[example]]
+name = "enum_derive"
+path = "../../examples/enum_derive.rs"
+required-features = ["derive"]

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -19,8 +19,8 @@ pub trait RlpDecodable: Sized {
 
 /// An active RLP decoder over a payload slice.
 ///
-/// Wraps a byte slice and provides methods for sequentially decoding RLP items, tracking byte position for error
-/// reporting.
+/// Wraps a byte slice and provides methods for sequentially decoding RLP items, tracking byte
+/// position for error reporting.
 #[derive(Debug)]
 pub struct Decoder<'de> {
     buf: &'de [u8],
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn decoder_basic() {
-        let data = crate::encode(&vec![1u64, 2u64, 3u64]);
+        let data = crate::encode(vec![1u64, 2u64, 3u64]);
         let mut decoder = Decoder::new(&data).unwrap();
         assert_eq!(decoder.decode_next::<u64>().unwrap(), Some(1));
         assert_eq!(decoder.decode_next::<u64>().unwrap(), Some(2));
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn decoder_with_start() {
-        let data = crate::encode(&vec![10u64, 20u64]);
+        let data = crate::encode(vec![10u64, 20u64]);
         let mut decoder = Decoder::with_start(&data, 100).unwrap();
         assert_eq!(decoder.decode_next::<u64>().unwrap(), Some(10));
         assert_eq!(decoder.decode_next::<u64>().unwrap(), Some(20));
@@ -543,7 +543,7 @@ mod tests {
 
     #[test]
     fn decoder_remaining() {
-        let data = crate::encode(&vec![1u64, 2u64]);
+        let data = crate::encode(vec![1u64, 2u64]);
         let mut decoder = Decoder::new(&data).unwrap();
         let initial_len = decoder.remaining().len();
         assert!(initial_len > 0);
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn decoder_error() {
-        let data = crate::encode(&vec![1u64]);
+        let data = crate::encode(vec![1u64]);
         let decoder = Decoder::new(&data).unwrap();
         let e = decoder.error(ErrorKind::Custom("test"));
         assert_eq!(e.kind, ErrorKind::Custom("test"));
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn decoder_decode_next_raw() {
-        let data = crate::encode(&vec![5u64, 6u64]);
+        let data = crate::encode(vec![5u64, 6u64]);
         let mut decoder = Decoder::new(&data).unwrap();
         // rlp_decode_raw defaults to rlp_decode, so this should work identically
         assert_eq!(decoder.decode_next_raw::<u64>().unwrap(), Some(5));
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn decoder_bytepos_advances() {
-        let data = crate::encode(&vec![1u64, 2u64]);
+        let data = crate::encode(vec![1u64, 2u64]);
         let mut decoder = Decoder::new(&data).unwrap();
         assert_eq!(decoder.bytepos(), 0);
         decoder.decode_next::<u64>().unwrap(); // consumes 1 byte (single-byte int 1)
@@ -674,7 +674,7 @@ mod tests {
 
     #[test]
     fn decoder_bytepos_with_start_offset() {
-        let data = crate::encode(&vec![1u64]);
+        let data = crate::encode(vec![1u64]);
         let mut decoder = Decoder::with_start(&data, 100).unwrap();
         assert_eq!(decoder.bytepos(), 100);
         decoder.decode_next::<u64>().unwrap();

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -1,9 +1,49 @@
 use core::fmt;
 
 /// RLP result type.
-pub type Result<T, E = ErrorKind> = core::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-// TODO: wrap in an `Error` struct with `bytepos` field once `Decoder` is introduced
+/// RLP error with byte position context.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Error {
+    /// The byte position in the input where the error occurred.
+    pub bytepos: usize,
+    /// The kind of error.
+    pub kind: ErrorKind,
+}
+
+impl Error {
+    /// Creates a new error with the given kind and byte position 0.
+    #[inline]
+    pub const fn new(kind: ErrorKind) -> Self {
+        Self { bytepos: 0, kind }
+    }
+
+    /// Creates a new error with the given kind and byte position.
+    #[inline]
+    pub const fn with_bytepos(kind: ErrorKind, bytepos: usize) -> Self {
+        Self { bytepos, kind }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    #[inline]
+    fn from(kind: ErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(all(feature = "core-error", not(feature = "std")))]
+impl core::error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (at byte {})", self.kind, self.bytepos)
+    }
+}
+
 /// RLP error type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
@@ -55,5 +95,65 @@ impl fmt::Display for ErrorKind {
             }
             Self::Custom(err) => f.write_str(err),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_new() {
+        let e = Error::new(ErrorKind::Overflow);
+        assert_eq!(e.bytepos, 0);
+        assert_eq!(e.kind, ErrorKind::Overflow);
+    }
+
+    #[test]
+    fn error_with_bytepos() {
+        let e = Error::with_bytepos(ErrorKind::InputTooShort, 42);
+        assert_eq!(e.bytepos, 42);
+        assert_eq!(e.kind, ErrorKind::InputTooShort);
+    }
+
+    #[test]
+    fn error_from_error_kind() {
+        let e: Error = ErrorKind::LeadingZero.into();
+        assert_eq!(e.bytepos, 0);
+        assert_eq!(e.kind, ErrorKind::LeadingZero);
+    }
+
+    #[test]
+    fn error_display() {
+        let e = Error::with_bytepos(ErrorKind::Overflow, 10);
+        assert_eq!(e.to_string(), "overflow (at byte 10)");
+    }
+
+    #[test]
+    fn error_display_list_length_mismatch() {
+        let e = Error::new(ErrorKind::ListLengthMismatch { expected: 3, got: 5 });
+        assert_eq!(e.to_string(), "unexpected list length (got 5, expected 3) (at byte 0)");
+    }
+
+    #[test]
+    fn error_display_custom() {
+        let e = Error::new(ErrorKind::Custom("bad data"));
+        assert_eq!(e.to_string(), "bad data (at byte 0)");
+    }
+
+    #[test]
+    fn error_eq_distinguishes_bytepos() {
+        let a = Error::with_bytepos(ErrorKind::Overflow, 0);
+        let b = Error::with_bytepos(ErrorKind::Overflow, 1);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn error_clone_copy() {
+        let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
+        let cloned = e.clone();
+        let copied = e;
+        assert_eq!(e, cloned);
+        assert_eq!(e, copied);
     }
 }

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -4,12 +4,12 @@ use core::fmt;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// RLP error with byte position context.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
     /// The byte position in the input where the error occurred.
-    pub bytepos: usize,
+    bytepos: usize,
     /// The kind of error.
-    pub kind: ErrorKind,
+    kind: ErrorKind,
 }
 
 impl Error {
@@ -23,6 +23,18 @@ impl Error {
     #[inline]
     pub const fn with_bytepos(kind: ErrorKind, bytepos: usize) -> Self {
         Self { bytepos, kind }
+    }
+
+    /// Returns the byte position in the input where the error occurred.
+    #[inline]
+    pub const fn bytepos(&self) -> usize {
+        self.bytepos
+    }
+
+    /// Returns the kind of error.
+    #[inline]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
     }
 }
 
@@ -106,22 +118,22 @@ mod tests {
     #[test]
     fn error_new() {
         let e = Error::new(ErrorKind::Overflow);
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::Overflow);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::Overflow);
     }
 
     #[test]
     fn error_with_bytepos() {
         let e = Error::with_bytepos(ErrorKind::InputTooShort, 42);
-        assert_eq!(e.bytepos, 42);
-        assert_eq!(e.kind, ErrorKind::InputTooShort);
+        assert_eq!(e.bytepos(), 42);
+        assert_eq!(e.kind(), ErrorKind::InputTooShort);
     }
 
     #[test]
     fn error_from_error_kind() {
         let e: Error = ErrorKind::LeadingZero.into();
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::LeadingZero);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::LeadingZero);
     }
 
     #[test]
@@ -150,11 +162,9 @@ mod tests {
     }
 
     #[test]
-    fn error_clone_copy() {
+    fn error_clone() {
         let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
-        let cloned = e;
-        let copied = e;
+        let cloned = e.clone();
         assert_eq!(e, cloned);
-        assert_eq!(e, copied);
     }
 }

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -101,6 +101,7 @@ impl fmt::Display for ErrorKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn error_new() {
@@ -151,7 +152,7 @@ mod tests {
     #[test]
     fn error_clone_copy() {
         let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
-        let cloned = e.clone();
+        let cloned = e;
         let copied = e;
         assert_eq!(e, cloned);
         assert_eq!(e, copied);

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -1,6 +1,5 @@
 use crate::{
-    decode::static_left_pad, Encoder, Error, ErrorKind, Result, EMPTY_LIST_CODE,
-    EMPTY_STRING_CODE,
+    decode::static_left_pad, Encoder, Error, ErrorKind, Result, EMPTY_LIST_CODE, EMPTY_STRING_CODE,
 };
 use bytes::Buf;
 use core::hint::unreachable_unchecked;
@@ -108,8 +107,7 @@ impl Header {
     #[inline]
     pub fn decode_str<'a>(buf: &mut &'a [u8]) -> Result<&'a str> {
         let bytes = Self::decode_bytes(buf, false)?;
-        core::str::from_utf8(bytes)
-            .map_err(|_| Error::new(ErrorKind::Custom("invalid string")))
+        core::str::from_utf8(bytes).map_err(|_| Error::new(ErrorKind::Custom("invalid string")))
     }
 
     /// Extracts the next payload from the given buffer, advancing it.

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -11,10 +11,11 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{decode_exact, Rlp, RlpDecodable};
+#[allow(deprecated)]
+pub use decode::{decode_exact, Decoder, Rlp, RlpDecodable};
 
 mod error;
-pub use error::{ErrorKind, Result};
+pub use error::{Error, ErrorKind, Result};
 
 mod encode;
 #[cfg(feature = "arrayvec")]
@@ -44,7 +45,7 @@ pub const EMPTY_LIST_CODE: u8 = 0xC0;
 
 // Not public API.
 #[doc(hidden)]
-#[deprecated(since = "0.3.0", note = "use `ErrorKind` instead")]
+#[deprecated(since = "0.3.0", note = "use `Error` or `ErrorKind` instead")]
 pub type DecodeError = ErrorKind;
 
 #[doc(hidden)]

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -288,7 +288,7 @@ fn tagged_enum_unknown_tag() {
     encoded[1] = 99;
     let result = OnlyOne::rlp_decode(&mut encoded.as_slice());
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind, ErrorKind::Custom("unknown variant tag"));
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Custom("unknown variant tag"));
 }
 
 /// Test that `#[rlp(tagged)]` roundtrips match the manual example in examples/enum.rs.
@@ -482,7 +482,7 @@ fn tuple_decode_trailing_bytes() {
     let data = alloy_rlp::encode((1u64, 2u64));
     let result = <(u64,)>::rlp_decode(&mut data.as_slice());
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind, ErrorKind::ListLengthMismatch { expected: 0, got: 1 });
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ListLengthMismatch { expected: 0, got: 1 });
 }
 
 /// Test tuple decode rejects too-few elements.
@@ -491,7 +491,7 @@ fn tuple_decode_too_few() {
     let data = alloy_rlp::encode((1u64,));
     let result = <(u64, u64)>::rlp_decode(&mut data.as_slice());
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind, ErrorKind::InputTooShort);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::InputTooShort);
 }
 
 /// Last trailing optional field roundtrips values that encode as 0x80.

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -19,7 +19,10 @@ fn simple_derive() {
     assert_eq!(thing, decoded);
 
     // does not panic on short input
-    assert_eq!(Err(ErrorKind::InputTooShort), MyThing::rlp_decode(&mut [0x8c; 11].as_ref()))
+    assert_eq!(
+        Err(Error::new(ErrorKind::InputTooShort)),
+        MyThing::rlp_decode(&mut [0x8c; 11].as_ref())
+    )
 }
 
 #[test]
@@ -105,6 +108,219 @@ fn multiple_attrs_combined() {
     assert_eq!(decoded2.cache, Cache::default());
 }
 
+/// Test `#[rlp(transparent)]` as a replacement for `RlpEncodableWrapper`/`RlpDecodableWrapper`.
+#[test]
+fn transparent_basic() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Wrapper {
+        inner: u64,
+    }
+
+    let w = Wrapper { inner: 42 };
+    let encoded = alloy_rlp::encode(&w);
+
+    // Should encode identically to the inner type (no list header)
+    let raw = alloy_rlp::encode(42u64);
+    assert_eq!(encoded, raw);
+
+    let decoded = Wrapper::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, w);
+}
+
+/// Test `#[rlp(transparent)]` with a skipped field.
+#[test]
+fn transparent_with_skip() {
+    #[derive(PartialEq, Debug, Default)]
+    struct NotEncodable;
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct WithSkip {
+        value: u64,
+        #[rlp(skip)]
+        _marker: NotEncodable,
+    }
+
+    let w = WithSkip { value: 99, _marker: NotEncodable };
+    let encoded = alloy_rlp::encode(&w);
+    assert_eq!(encoded, alloy_rlp::encode(99u64));
+
+    let decoded = WithSkip::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded.value, 99);
+}
+
+/// Test `#[rlp(transparent)]` with a tuple struct.
+#[test]
+fn transparent_tuple() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Wrap(u64);
+
+    let w = Wrap(123);
+    let encoded = alloy_rlp::encode(&w);
+    assert_eq!(encoded, alloy_rlp::encode(123u64));
+
+    let decoded = Wrap::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, w);
+}
+
+/// Test `#[rlp(tagged)]` on an enum with unnamed fields.
+#[test]
+fn tagged_enum_unnamed() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum FooBar {
+        Foo(u64),
+        Bar(u16, u64),
+    }
+
+    let val = FooBar::Foo(42);
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = FooBar::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+
+    let val = FooBar::Bar(7, 42);
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = FooBar::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test `#[rlp(tagged)]` on an enum with unit variants.
+#[test]
+fn tagged_enum_unit() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Signal {
+        Ping,
+        Pong,
+    }
+
+    let val = Signal::Ping;
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Signal::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+
+    let val = Signal::Pong;
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Signal::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test `#[rlp(tagged)]` with named fields.
+#[test]
+fn tagged_enum_named() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Msg {
+        Hello { version: u64 },
+        Data { a: u16, b: u64 },
+    }
+
+    let val = Msg::Hello { version: 5 };
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Msg::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+
+    let val = Msg::Data { a: 7, b: 42 };
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Msg::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test `#[rlp(tagged)]` with explicit discriminant values.
+#[test]
+fn tagged_enum_discriminant() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Cmd {
+        Start = 10,
+        Stop = 20,
+    }
+
+    let val = Cmd::Start;
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Cmd::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+
+    let val = Cmd::Stop;
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Cmd::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test `#[rlp(tag = <expr>)]` per-variant override.
+#[test]
+fn tagged_enum_tag_attr() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Custom {
+        #[rlp(tag = 0x80)]
+        Alpha,
+        #[rlp(tag = 0xFF)]
+        Beta(u64),
+    }
+
+    let val = Custom::Alpha;
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Custom::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+
+    let val = Custom::Beta(999);
+    let encoded = alloy_rlp::encode(&val);
+    let decoded = Custom::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test that unknown tags produce an error on decode.
+#[test]
+fn tagged_enum_unknown_tag() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum OnlyOne {
+        A,
+    }
+
+    // Encode variant A (tag 0), then mutate tag to 99
+    let mut encoded = alloy_rlp::encode(&OnlyOne::A);
+    // The encoding is a list [tag]. For tag=0 (RLP: 0x80), the list is [0xC1, 0x80].
+    // Change the tag byte to 99 (which is < 0x80, so it's a single-byte RLP)
+    encoded[1] = 99;
+    let result = OnlyOne::rlp_decode(&mut encoded.as_slice());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind, ErrorKind::Custom("unknown variant tag"));
+}
+
+/// Test that `#[rlp(tagged)]` roundtrips match the manual example in examples/enum.rs.
+#[test]
+fn tagged_enum_matches_manual() {
+    // The manual FooBar example encodes Foo(42) as list [0u8, 42u64]
+    // Our derived version should produce the same encoding
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum FooBar {
+        Foo(u64),
+        Bar(u16, u64),
+    }
+
+    let derived_foo = alloy_rlp::encode(&FooBar::Foo(42));
+    let derived_bar = alloy_rlp::encode(&FooBar::Bar(7, 42));
+
+    // Build the expected encoding manually using encode_list
+    use alloy_rlp::{encode_list, Encoder};
+
+    let mut expected_foo = Vec::new();
+    let enc: [&dyn RlpEncodable; 2] = [&0u8, &42u64];
+    encode_list::<_, dyn RlpEncodable>(&enc, &mut Encoder::new(&mut expected_foo));
+
+    let mut expected_bar = Vec::new();
+    let enc: [&dyn RlpEncodable; 3] = [&1u8, &7u16, &42u64];
+    encode_list::<_, dyn RlpEncodable>(&enc, &mut Encoder::new(&mut expected_bar));
+
+    assert_eq!(derived_foo, expected_foo);
+    assert_eq!(derived_bar, expected_bar);
+}
+
 /// Test that `#[rlp(skip)]` alone works.
 #[test]
 fn skip_field() {
@@ -131,4 +347,149 @@ fn skip_field() {
 
     let decoded = WithoutSkip::rlp_decode(&mut buf.as_slice()).unwrap();
     assert_eq!(decoded.value, 42);
+}
+
+/// Test `#[rlp(flatten)]` field attribute.
+#[test]
+fn flatten_field() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+        b: u64,
+    }
+
+    // Without flatten: Outer encodes as [x, [a, b]] (nested list)
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterNested {
+        x: u64,
+        inner: Inner,
+    }
+
+    // With flatten: Outer encodes as [x, a, b] (fields inlined)
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterFlat {
+        x: u64,
+        #[rlp(flatten)]
+        inner: Inner,
+    }
+
+    let nested = OuterNested { x: 1, inner: Inner { a: 2, b: 3 } };
+    let flat = OuterFlat { x: 1, inner: Inner { a: 2, b: 3 } };
+
+    let nested_encoded = alloy_rlp::encode(&nested);
+    let flat_encoded = alloy_rlp::encode(&flat);
+
+    // They should be different: nested has [1, [2, 3]], flat has [1, 2, 3]
+    assert_ne!(nested_encoded, flat_encoded);
+
+    // Flat should encode/decode as [x, a, b] — same as a 3-field struct
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct ThreeFields {
+        x: u64,
+        a: u64,
+        b: u64,
+    }
+
+    let three = ThreeFields { x: 1, a: 2, b: 3 };
+    let three_encoded = alloy_rlp::encode(&three);
+    assert_eq!(flat_encoded, three_encoded);
+
+    // Roundtrip flat
+    let decoded = OuterFlat::rlp_decode(&mut flat_encoded.as_slice()).unwrap();
+    assert_eq!(decoded, flat);
+}
+
+/// Test `#[rlp(flatten)]` with multiple flattened fields.
+#[test]
+fn flatten_multiple() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct A {
+        x: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct B {
+        y: u16,
+        z: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Combined {
+        #[rlp(flatten)]
+        a: A,
+        #[rlp(flatten)]
+        b: B,
+    }
+
+    let val = Combined { a: A { x: 10 }, b: B { y: 20, z: 30 } };
+    let encoded = alloy_rlp::encode(&val);
+
+    // Should encode as [10, 20, 30] — same as a flat 3-field struct
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat3 {
+        x: u64,
+        y: u16,
+        z: u64,
+    }
+    let flat = Flat3 { x: 10, y: 20, z: 30 };
+    assert_eq!(encoded, alloy_rlp::encode(&flat));
+
+    let decoded = Combined::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, val);
+}
+
+/// Test `#[rlp(flatten)]` with a skipped field alongside.
+#[test]
+fn flatten_with_skip() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+    }
+
+    #[derive(PartialEq, Debug, Default)]
+    struct NotRlp;
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Outer {
+        x: u64,
+        #[rlp(flatten)]
+        inner: Inner,
+        #[rlp(default, skip)]
+        _cache: NotRlp,
+    }
+
+    let val = Outer { x: 1, inner: Inner { a: 2 }, _cache: NotRlp };
+    let encoded = alloy_rlp::encode(&val);
+
+    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded.x, 1);
+    assert_eq!(decoded.inner.a, 2);
+}
+
+/// Test tuple encode/decode roundtrip with larger arities.
+#[test]
+fn tuple_larger_arity() {
+    let t5 = (1u8, 2u16, 3u32, 4u64, 5u128);
+    let encoded = alloy_rlp::encode(t5);
+    let decoded = <(u8, u16, u32, u64, u128)>::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, t5);
+}
+
+/// Test tuple decode rejects trailing bytes.
+#[test]
+fn tuple_decode_trailing_bytes() {
+    // Encode (1u64, 2u64) then try to decode as (u64,) — should fail due to extra data
+    let data = alloy_rlp::encode((1u64, 2u64));
+    let result = <(u64,)>::rlp_decode(&mut data.as_slice());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind, ErrorKind::ListLengthMismatch { expected: 0, got: 1 });
+}
+
+/// Test tuple decode rejects too-few elements.
+#[test]
+fn tuple_decode_too_few() {
+    let data = alloy_rlp::encode((1u64,));
+    let result = <(u64, u64)>::rlp_decode(&mut data.as_slice());
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind, ErrorKind::InputTooShort);
 }

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -303,8 +303,8 @@ fn tagged_enum_matches_manual() {
         Bar(u16, u64),
     }
 
-    let derived_foo = alloy_rlp::encode(&FooBar::Foo(42));
-    let derived_bar = alloy_rlp::encode(&FooBar::Bar(7, 42));
+    let derived_foo = alloy_rlp::encode(FooBar::Foo(42));
+    let derived_bar = alloy_rlp::encode(FooBar::Bar(7, 42));
 
     // Build the expected encoding manually using encode_list
     use alloy_rlp::{encode_list, Encoder};

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,7 +1,9 @@
 //! This example demonstrates how to encode and decode an enum using
 //! `alloy_rlp`.
 
-use alloy_rlp::{encode, encode_list, Encoder, ErrorKind, Header, RlpDecodable, RlpEncodable};
+use alloy_rlp::{
+    encode, encode_list, Encoder, Error, ErrorKind, Header, RlpDecodable, RlpEncodable,
+};
 
 #[derive(Debug, PartialEq)]
 enum FooBar {
@@ -25,12 +27,12 @@ impl RlpEncodable for FooBar {
 }
 
 impl RlpDecodable for FooBar {
-    fn rlp_decode(data: &mut &[u8]) -> Result<Self, ErrorKind> {
+    fn rlp_decode(data: &mut &[u8]) -> Result<Self, Error> {
         let mut payload = Header::decode_bytes(data, true)?;
         match u8::rlp_decode(&mut payload)? {
             0 => Ok(Self::Foo(u64::rlp_decode(&mut payload)?)),
             1 => Ok(Self::Bar(u16::rlp_decode(&mut payload)?, u64::rlp_decode(&mut payload)?)),
-            _ => Err(ErrorKind::Custom("unknown type")),
+            _ => Err(ErrorKind::Custom("unknown type").into()),
         }
     }
 }

--- a/examples/enum_derive.rs
+++ b/examples/enum_derive.rs
@@ -1,0 +1,91 @@
+//! This example demonstrates deriving RlpEncodable/RlpDecodable for enums
+//! using `#[rlp(tagged)]`.
+
+use alloy_rlp::{encode, RlpDecodable, RlpEncodable};
+
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[rlp(tagged)]
+enum FooBar {
+    Foo(u64),
+    Bar(u16, u64),
+}
+
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[rlp(tagged)]
+enum WithNamed {
+    A { x: u64, y: u16 },
+    B { z: u64 },
+}
+
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[rlp(tagged)]
+enum WithUnit {
+    Empty,
+    Value(u64),
+}
+
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[rlp(tagged)]
+enum WithCustomTags {
+    #[rlp(tag = 10)]
+    A(u64),
+    #[rlp(tag = 20)]
+    B(u16),
+}
+
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[rlp(tagged)]
+#[repr(u8)]
+enum WithDiscriminant {
+    A(u64) = 5,
+    B(u16) = 7,
+}
+
+fn main() {
+    // Unnamed fields (tuple variants)
+    let val = FooBar::Foo(42);
+    let out = encode(&val);
+    assert_eq!(FooBar::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    let val = FooBar::Bar(7, 42);
+    let out = encode(&val);
+    assert_eq!(FooBar::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    // Named fields
+    let val = WithNamed::A { x: 100, y: 200 };
+    let out = encode(&val);
+    assert_eq!(WithNamed::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    let val = WithNamed::B { z: 999 };
+    let out = encode(&val);
+    assert_eq!(WithNamed::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    // Unit variants
+    let val = WithUnit::Empty;
+    let out = encode(&val);
+    assert_eq!(WithUnit::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    let val = WithUnit::Value(123);
+    let out = encode(&val);
+    assert_eq!(WithUnit::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    // Custom tags
+    let val = WithCustomTags::A(42);
+    let out = encode(&val);
+    assert_eq!(WithCustomTags::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    let val = WithCustomTags::B(7);
+    let out = encode(&val);
+    assert_eq!(WithCustomTags::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    // Discriminant-based tags
+    let val = WithDiscriminant::A(42);
+    let out = encode(&val);
+    assert_eq!(WithDiscriminant::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    let val = WithDiscriminant::B(7);
+    let out = encode(&val);
+    assert_eq!(WithDiscriminant::rlp_decode(&mut out.as_ref()), Ok(val));
+
+    println!("all enum derive tests passed!");
+}


### PR DESCRIPTION
Closes #14

Implements the remaining items from the new library and macro API:

- `RlpEncodable`/`RlpDecodable` impls for tuples (arity 1–12), encoding as RLP lists
- `#[rlp(flatten)]` field attribute using `rlp_encode_raw`/`rlp_decode_raw`/`rlp_len_raw`
- Tagged enum trailing-bytes validation
- Compile-time rejection of `#[rlp(flatten)]` on `Option<T>` fields
- Saturating arithmetic in `Decoder::bytepos`
- Sentinel-aware optional decoding in `rlp_decode_raw`