### PR TITLE
feat: introduce `Error` struct wrapping `ErrorKind` with `bytepos`

### DIFF
--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -44,12 +44,12 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
                     let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(b)?;
                     if !list {
-                        return Err(alloy_rlp::ErrorKind::UnexpectedString);
+                        return Err(alloy_rlp::ErrorKind::UnexpectedString.into());
                     }
 
                     let started_len = b.len();
                     if started_len < payload_length {
-                        return Err(alloy_rlp::ErrorKind::InputTooShort);
+                        return Err(alloy_rlp::ErrorKind::InputTooShort.into());
                     }
 
                     let this = Self {
@@ -61,7 +61,7 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                         return Err(alloy_rlp::ErrorKind::ListLengthMismatch {
                             expected: payload_length,
                             got: consumed,
-                        });
+                        }.into());
                     }
 
                     Ok(this)

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -1,9 +1,49 @@
 use core::fmt;
 
 /// RLP result type.
-pub type Result<T, E = ErrorKind> = core::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-// TODO: wrap in an `Error` struct with `bytepos` field once `Decoder` is introduced
+/// RLP error with byte position context.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Error {
+    /// The byte position in the input where the error occurred.
+    pub bytepos: usize,
+    /// The kind of error.
+    pub kind: ErrorKind,
+}
+
+impl Error {
+    /// Creates a new error with the given kind and byte position 0.
+    #[inline]
+    pub const fn new(kind: ErrorKind) -> Self {
+        Self { bytepos: 0, kind }
+    }
+
+    /// Creates a new error with the given kind and byte position.
+    #[inline]
+    pub const fn with_bytepos(kind: ErrorKind, bytepos: usize) -> Self {
+        Self { bytepos, kind }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    #[inline]
+    fn from(kind: ErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(all(feature = "core-error", not(feature = "std")))]
+impl core::error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (at byte {})", self.kind, self.bytepos)
+    }
+}
+
 /// RLP error type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
@@ -55,5 +95,66 @@ impl fmt::Display for ErrorKind {
             }
             Self::Custom(err) => f.write_str(err),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn error_new() {
+        let e = Error::new(ErrorKind::Overflow);
+        assert_eq!(e.bytepos, 0);
+        assert_eq!(e.kind, ErrorKind::Overflow);
+    }
+
+    #[test]
+    fn error_with_bytepos() {
+        let e = Error::with_bytepos(ErrorKind::InputTooShort, 42);
+        assert_eq!(e.bytepos, 42);
+        assert_eq!(e.kind, ErrorKind::InputTooShort);
+    }
+
+    #[test]
+    fn error_from_error_kind() {
+        let e: Error = ErrorKind::LeadingZero.into();
+        assert_eq!(e.bytepos, 0);
+        assert_eq!(e.kind, ErrorKind::LeadingZero);
+    }
+
+    #[test]
+    fn error_display() {
+        let e = Error::with_bytepos(ErrorKind::Overflow, 10);
+        assert_eq!(e.to_string(), "overflow (at byte 10)");
+    }
+
+    #[test]
+    fn error_display_list_length_mismatch() {
+        let e = Error::new(ErrorKind::ListLengthMismatch { expected: 3, got: 5 });
+        assert_eq!(e.to_string(), "unexpected list length (got 5, expected 3) (at byte 0)");
+    }
+
+    #[test]
+    fn error_display_custom() {
+        let e = Error::new(ErrorKind::Custom("bad data"));
+        assert_eq!(e.to_string(), "bad data (at byte 0)");
+    }
+
+    #[test]
+    fn error_eq_distinguishes_bytepos() {
+        let a = Error::with_bytepos(ErrorKind::Overflow, 0);
+        let b = Error::with_bytepos(ErrorKind::Overflow, 1);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn error_clone_copy() {
+        let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
+        let cloned = e;
+        let copied = e;
+        assert_eq!(e, cloned);
+        assert_eq!(e, copied);
     }
 }

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decode::static_left_pad, Encoder, ErrorKind, Result, EMPTY_LIST_CODE, EMPTY_STRING_CODE,
+    decode::static_left_pad, Encoder, Error, ErrorKind, Result, EMPTY_LIST_CODE, EMPTY_STRING_CODE,
 };
 use bytes::Buf;
 use core::hint::unreachable_unchecked;
@@ -30,7 +30,7 @@ impl Header {
                 buf.advance(1);
                 payload_length = (b - EMPTY_STRING_CODE) as usize;
                 if payload_length == 1 && get_next_byte(buf)? < EMPTY_STRING_CODE {
-                    return Err(ErrorKind::NonCanonicalSingleByte);
+                    return Err(ErrorKind::NonCanonicalSingleByte.into());
                 }
             }
 
@@ -49,17 +49,17 @@ impl Header {
                 }
 
                 if buf.len() < len_of_len {
-                    return Err(ErrorKind::InputTooShort);
+                    return Err(ErrorKind::InputTooShort.into());
                 }
                 // SAFETY: length checked above
                 let len = unsafe { buf.get_unchecked(..len_of_len) };
                 buf.advance(len_of_len);
 
                 let len = u64::from_be_bytes(static_left_pad(len)?);
-                payload_length =
-                    usize::try_from(len).map_err(|_| ErrorKind::Custom("Input too big"))?;
+                payload_length = usize::try_from(len)
+                    .map_err(|_| Error::new(ErrorKind::Custom("Input too big")))?;
                 if payload_length < 56 {
-                    return Err(ErrorKind::NonCanonicalSize);
+                    return Err(ErrorKind::NonCanonicalSize.into());
                 }
             }
 
@@ -71,7 +71,7 @@ impl Header {
         }
 
         if buf.remaining() < payload_length {
-            return Err(ErrorKind::InputTooShort);
+            return Err(ErrorKind::InputTooShort.into());
         }
 
         Ok(Self { list, payload_length })
@@ -88,9 +88,9 @@ impl Header {
 
         if list != is_list {
             return Err(if is_list {
-                ErrorKind::UnexpectedString
+                ErrorKind::UnexpectedString.into()
             } else {
-                ErrorKind::UnexpectedList
+                ErrorKind::UnexpectedList.into()
             });
         }
 
@@ -107,7 +107,7 @@ impl Header {
     #[inline]
     pub fn decode_str<'a>(buf: &mut &'a [u8]) -> Result<&'a str> {
         let bytes = Self::decode_bytes(buf, false)?;
-        core::str::from_utf8(bytes).map_err(|_| ErrorKind::Custom("invalid string"))
+        core::str::from_utf8(bytes).map_err(|_| Error::new(ErrorKind::Custom("invalid string")))
     }
 
     /// Extracts the next payload from the given buffer, advancing it.
@@ -190,7 +190,7 @@ pub enum PayloadView<'a> {
 #[inline(always)]
 fn get_next_byte(buf: &[u8]) -> Result<u8> {
     if buf.is_empty() {
-        return Err(ErrorKind::InputTooShort);
+        return Err(ErrorKind::InputTooShort.into());
     }
     // SAFETY: length checked above
     Ok(*unsafe { buf.get_unchecked(0) })

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -14,7 +14,7 @@ mod decode;
 pub use decode::{decode_exact, Rlp, RlpDecodable};
 
 mod error;
-pub use error::{ErrorKind, Result};
+pub use error::{Error, ErrorKind, Result};
 
 mod encode;
 #[cfg(feature = "arrayvec")]
@@ -44,7 +44,7 @@ pub const EMPTY_LIST_CODE: u8 = 0xC0;
 
 // Not public API.
 #[doc(hidden)]
-#[deprecated(since = "0.3.0", note = "use `ErrorKind` instead")]
+#[deprecated(since = "0.3.0", note = "use `Error` or `ErrorKind` instead")]
 pub type DecodeError = ErrorKind;
 
 #[doc(hidden)]

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -19,7 +19,10 @@ fn simple_derive() {
     assert_eq!(thing, decoded);
 
     // does not panic on short input
-    assert_eq!(Err(ErrorKind::InputTooShort), MyThing::rlp_decode(&mut [0x8c; 11].as_ref()))
+    assert_eq!(
+        Err(Error::new(ErrorKind::InputTooShort)),
+        MyThing::rlp_decode(&mut [0x8c; 11].as_ref())
+    )
 }
 
 #[test]

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,7 +1,9 @@
 //! This example demonstrates how to encode and decode an enum using
 //! `alloy_rlp`.
 
-use alloy_rlp::{encode, encode_list, Encoder, ErrorKind, Header, RlpDecodable, RlpEncodable};
+use alloy_rlp::{
+    encode, encode_list, Encoder, Error, ErrorKind, Header, RlpDecodable, RlpEncodable,
+};
 
 #[derive(Debug, PartialEq)]
 enum FooBar {
@@ -25,12 +27,12 @@ impl RlpEncodable for FooBar {
 }
 
 impl RlpDecodable for FooBar {
-    fn rlp_decode(data: &mut &[u8]) -> Result<Self, ErrorKind> {
+    fn rlp_decode(data: &mut &[u8]) -> Result<Self, Error> {
         let mut payload = Header::decode_bytes(data, true)?;
         match u8::rlp_decode(&mut payload)? {
             0 => Ok(Self::Foo(u64::rlp_decode(&mut payload)?)),
             1 => Ok(Self::Bar(u16::rlp_decode(&mut payload)?, u64::rlp_decode(&mut payload)?)),
-            _ => Err(ErrorKind::Custom("unknown type")),
+            _ => Err(ErrorKind::Custom("unknown type").into()),
         }
     }
 }


### PR DESCRIPTION
Introduce `Error` struct wrapping `ErrorKind` with a `bytepos` field for byte-position context in decoding errors. Migrate all error return sites to use `.into()`.

Split from #48.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
- [ ] Updated CHANGELOG.md