### PR TITLE
feat: implement raw RLP flattening and tagged derives

### DIFF
--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -1,20 +1,49 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Error, Result};
 
 pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    if attributes_include(&ast.attrs, "tagged") {
+        return impl_decodable_tagged(ast);
+    }
+    if matches!(ast.data, syn::Data::Enum(_)) {
+        let msg = "RLP enum derives require `#[rlp(tagged)]`";
+        return Err(Error::new_spanned(ast, msg));
+    }
+
     let body = parse_struct(ast, "RlpDecodable")?;
 
-    let fields = body.fields.iter().enumerate();
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_decodable_transparent(ast, body);
+    }
+
+    let all_fields: Vec<_> = body.fields.iter().enumerate().collect();
 
     let supports_trailing_opt = attributes_include(&ast.attrs, "trailing");
 
+    let last_consuming_idx = all_fields
+        .iter()
+        .rev()
+        .find(|(_, field)| {
+            !attributes_include(&field.attrs, "skip")
+                && !attributes_include(&field.attrs, "default")
+        })
+        .map(|(i, _)| *i);
+
     let mut encountered_opt_item = false;
     let mut decode_stmts = Vec::with_capacity(body.fields.len());
-    for (i, field) in fields {
+    let mut decode_stmts_raw = Vec::with_capacity(body.fields.len());
+    for &(i, field) in &all_fields {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -28,7 +57,9 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
             return Err(Error::new_spanned(field, msg));
         }
 
-        decode_stmts.push(decodable_field(i, field, is_opt));
+        let is_last_consuming = last_consuming_idx == Some(i);
+        decode_stmts.push(decodable_field(i, field, is_opt, is_last_consuming));
+        decode_stmts_raw.push(decodable_field_raw(i, field));
     }
 
     let name = &ast.ident;
@@ -66,6 +97,84 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
                     Ok(this)
                 }
+
+                #[inline]
+                fn rlp_decode_raw(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    Ok(Self {
+                        #(#decode_stmts_raw)*
+                    })
+                }
+            }
+        };
+    })
+}
+
+fn impl_decodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let field_inits: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let ident = field_ident(i, field);
+            if attributes_include(&field.attrs, "skip") {
+                quote! { #ident: alloy_rlp::private::Default::default(), }
+            } else {
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(buf)?, }
+            }
+        })
+        .collect();
+
+    let field_inits_raw: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let ident = field_ident(i, field);
+            if attributes_include(&field.attrs, "skip") {
+                quote! { #ident: alloy_rlp::private::Default::default(), }
+            } else {
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(buf)?, }
+            }
+        })
+        .collect();
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::Ok(Self {
+                        #(#field_inits)*
+                    })
+                }
+
+                #[inline]
+                fn rlp_decode_raw(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::Ok(Self {
+                        #(#field_inits_raw)*
+                    })
+                }
             }
         };
     })
@@ -97,25 +206,131 @@ pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStre
     })
 }
 
-fn decodable_field(index: usize, field: &syn::Field, is_opt: bool) -> TokenStream {
+fn decodable_field(
+    index: usize,
+    field: &syn::Field,
+    is_opt: bool,
+    is_last_consuming: bool,
+) -> TokenStream {
     let ident = field_ident(index, field);
 
-    if attributes_include(&field.attrs, "default") {
+    if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
         quote! { #ident: alloy_rlp::private::Default::default(), }
     } else if is_opt {
-        quote! {
-            #ident: if started_len - b.len() < payload_length {
-                if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
-                    alloy_rlp::Buf::advance(b, 1);
-                    None
-                } else {
+        if is_last_consuming {
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
                     Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
-                }
-            } else {
-                None
-            },
+                } else {
+                    None
+                },
+            }
+        } else {
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
+                    if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
+                        alloy_rlp::Buf::advance(b, 1);
+                        None
+                    } else {
+                        Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
+                    }
+                } else {
+                    None
+                },
+            }
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
     } else {
         quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
     }
+}
+
+fn decodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
+        quote! { #ident: alloy_rlp::private::Default::default(), }
+    } else if is_optional(field) {
+        quote! { #ident: alloy_rlp::private::None, }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
+    } else {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
+    }
+}
+
+pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpDecodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+        let tag_expr = variant_tag_expr(i, variant)?;
+
+        let construct = match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_decodes = fields.named.iter().map(|f| {
+                    let fname = f.ident.as_ref().unwrap();
+                    quote! { #fname: alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? }
+                });
+                quote! { #name::#var_ident { #(#field_decodes),* } }
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_decodes = (0..fields.unnamed.len())
+                    .map(|_| quote! { alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? });
+                quote! { #name::#var_ident(#(#field_decodes),*) }
+            }
+            syn::Fields::Unit => quote! { #name::#var_ident },
+        };
+
+        match_arms.push(quote! {
+            tag if tag == (#tag_expr) as u64 => alloy_rlp::private::Ok(#construct),
+        });
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    let mut payload = alloy_rlp::Header::decode_bytes(b, true)?;
+                    let tag = <u64 as alloy_rlp::RlpDecodable>::rlp_decode(&mut payload)?;
+                    let value = match tag {
+                        #(#match_arms)*
+                        _ => alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::Custom("unknown variant tag"))),
+                    }?;
+                    if !payload.is_empty() {
+                        return alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::ListLengthMismatch {
+                            expected: 0,
+                            got: payload.len(),
+                        }));
+                    }
+                    alloy_rlp::private::Ok(value)
+                }
+            }
+        };
+    })
+}
+
+fn variant_tag_expr(index: usize, variant: &syn::Variant) -> Result<TokenStream> {
+    Ok(get_tag_value(&variant.attrs)?.map_or_else(
+        || {
+            variant.discriminant.as_ref().map_or_else(
+                || {
+                    let index = index as u64;
+                    quote! { #index }
+                },
+                |(_, expr)| quote! { #expr },
+            )
+        },
+        |expr| quote! { #expr },
+    ))
 }

--- a/crates/rlp-derive/src/en.rs
+++ b/crates/rlp-derive/src/en.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -7,7 +8,19 @@ use std::iter::Peekable;
 use syn::{Error, Result};
 
 pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    if attributes_include(&ast.attrs, "tagged") {
+        return impl_encodable_tagged(ast);
+    }
+    if matches!(ast.data, syn::Data::Enum(_)) {
+        let msg = "RLP enum derives require `#[rlp(tagged)]`";
+        return Err(Error::new_spanned(ast, msg));
+    }
+
     let body = parse_struct(ast, "RlpEncodable")?;
+
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_encodable_transparent(ast, body);
+    }
 
     let mut fields = body
         .fields
@@ -21,8 +34,16 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let mut encountered_opt_item = false;
     let mut length_exprs = Vec::with_capacity(body.fields.len());
     let mut encode_exprs = Vec::with_capacity(body.fields.len());
+    let mut length_exprs_raw = Vec::with_capacity(body.fields.len());
+    let mut encode_exprs_raw = Vec::with_capacity(body.fields.len());
 
     while let Some((i, field)) = fields.next() {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -37,6 +58,10 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
         length_exprs.push(encodable_length(i, field, is_opt, fields.clone()));
         encode_exprs.push(encodable_field(i, field, is_opt, fields.clone()));
+        if !is_opt && !attributes_include(&field.attrs, "default") {
+            length_exprs_raw.push(encodable_length_raw(i, field));
+            encode_exprs_raw.push(encodable_field_raw(i, field));
+        }
     }
 
     let name = &ast.ident;
@@ -63,6 +88,16 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                     .encode(out);
                     #(#encode_exprs)*
                 }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    self._alloy_rlp_payload_length_raw()
+                }
+
+                #[inline]
+                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    #(#encode_exprs_raw)*
+                }
             }
 
             impl #impl_generics #name #ty_generics #where_clause {
@@ -70,6 +105,64 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 #[inline]
                 fn _alloy_rlp_payload_length(&self) -> usize {
                     0usize #( + #length_exprs)*
+                }
+
+                #[allow(unused_parens)]
+                #[inline]
+                fn _alloy_rlp_payload_length_raw(&self) -> usize {
+                    0usize #( + #length_exprs_raw)*
+                }
+            }
+        };
+    })
+}
+
+fn impl_encodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let (index, field) = non_skipped[0];
+    let ident = field_ident(index, field);
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out)
+                }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out)
                 }
             }
         };
@@ -175,6 +268,18 @@ fn encodable_length<'a>(
         };
 
         quote! { self.#ident.as_ref().map(|val| alloy_rlp::RlpEncodable::rlp_len(val)).unwrap_or(#default) }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
+    } else {
+        quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
+    }
+}
+
+fn encodable_length_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
     }
@@ -206,6 +311,18 @@ fn encodable_field<'a>(
         } else {
             quote! { #if_some_encode }
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
+    } else {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
+    }
+}
+
+fn encodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
     }
@@ -219,4 +336,132 @@ fn remaining_opt_fields_some_condition<'a>(
         quote! { self.#ident.is_some() }
     });
     quote! { #(#conditions)||* }
+}
+
+pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpEncodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut length_arms = Vec::new();
+    let mut encode_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+        let tag_expr = variant_tag_expr(i, variant)?;
+
+        match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_names: Vec<_> =
+                    fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+
+                let length_fields =
+                    field_names.iter().map(|f| quote! { alloy_rlp::RlpEncodable::rlp_len(#f) });
+                let encode_fields = field_names
+                    .iter()
+                    .map(|f| quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); });
+
+                length_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|j| syn::Ident::new(&format!("f{j}"), var_ident.span()))
+                    .collect();
+
+                let length_fields =
+                    field_names.iter().map(|f| quote! { alloy_rlp::RlpEncodable::rlp_len(#f) });
+                let encode_fields = field_names
+                    .iter()
+                    .map(|f| quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); });
+
+                length_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unit => {
+                length_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag)
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    payload_length + alloy_rlp::length_of_length(payload_length)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    alloy_rlp::Header {
+                        list: true,
+                        payload_length,
+                    }
+                    .encode(out);
+                    match self {
+                        #(#encode_arms)*
+                    }
+                }
+            }
+        };
+    })
+}
+
+fn variant_tag_expr(index: usize, variant: &syn::Variant) -> Result<TokenStream> {
+    Ok(get_tag_value(&variant.attrs)?.map_or_else(
+        || {
+            variant.discriminant.as_ref().map_or_else(
+                || {
+                    let index = index as u64;
+                    quote! { #index }
+                },
+                |(_, expr)| quote! { #expr },
+            )
+        },
+        |expr| quote! { #expr },
+    ))
 }

--- a/crates/rlp-derive/src/utils.rs
+++ b/crates/rlp-derive/src/utils.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse_quote, Attribute, DataStruct, Error, Field, GenericParam, Generics, Meta, Result, Type,
-    TypePath,
+    parse_quote, Attribute, DataEnum, DataStruct, Error, Field, GenericParam, Generics, Meta,
+    Result, Type, TypePath,
 };
 
 pub(crate) const EMPTY_STRING_CODE: u8 = 0x80;
@@ -17,6 +17,17 @@ pub(crate) fn parse_struct<'a>(
         Err(Error::new_spanned(
             ast,
             format!("#[derive({derive_attr})] is only defined for structs."),
+        ))
+    }
+}
+
+pub(crate) fn parse_enum<'a>(ast: &'a syn::DeriveInput, derive_attr: &str) -> Result<&'a DataEnum> {
+    if let syn::Data::Enum(e) = &ast.data {
+        Ok(e)
+    } else {
+        Err(Error::new_spanned(
+            ast,
+            format!("#[derive({derive_attr})] with `#[rlp(tagged)]` is only defined for enums."),
         ))
     }
 }
@@ -39,6 +50,23 @@ pub(crate) fn attributes_include(attrs: &[Attribute], attr_name: &str) -> bool {
         }
     }
     false
+}
+
+pub(crate) fn get_tag_value(attrs: &[Attribute]) -> Result<Option<syn::Expr>> {
+    let mut value = None;
+    for attr in attrs {
+        if attr.path().is_ident("rlp") {
+            if let Meta::List(meta) = &attr.meta {
+                meta.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("tag") {
+                        value = Some(meta.value()?.parse()?);
+                    }
+                    Ok(())
+                })?;
+            }
+        }
+    }
+    Ok(value)
 }
 
 pub(crate) fn is_optional(field: &Field) -> bool {

--- a/crates/rlp/README.md
+++ b/crates/rlp/README.md
@@ -36,3 +36,35 @@ let decoded = MyStruct::rlp_decode(&mut buffer.as_slice()).unwrap();
 assert_eq!(my_struct, decoded);
 # }
 ```
+
+The derive macros reject ambiguous enum and flatten shapes:
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+enum NotTagged {
+    A,
+}
+```
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+struct BadFlatten {
+    #[rlp(flatten)]
+    field: Option<u64>,
+}
+```
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+#[rlp(transparent)]
+struct BadTransparent {
+    a: u64,
+    b: u64,
+}
+```

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorKind, Header, Result};
+use crate::{Error, ErrorKind, Header, Result};
 use bytes::{Bytes, BytesMut};
 use core::marker::{PhantomData, PhantomPinned};
 
@@ -7,6 +7,154 @@ pub trait RlpDecodable: Sized {
     /// Decodes the blob into the appropriate type. `buf` must be advanced past
     /// the decoded object.
     fn rlp_decode(buf: &mut &[u8]) -> Result<Self>;
+
+    /// Decodes this value from a buffer that omits the value's outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by decoding the value normally.
+    /// Structured implementations may override this to read their fields sequentially.
+    #[inline]
+    fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
+        Self::rlp_decode(buf)
+    }
+}
+
+/// An active RLP decoder that tracks byte position while advancing through an input buffer.
+#[derive(Clone, Debug)]
+pub struct Decoder<'de> {
+    buf: &'de [u8],
+    bytepos: usize,
+}
+
+impl<'de> Decoder<'de> {
+    /// Instantiate an RLP decoder with an input slice.
+    #[inline]
+    pub const fn new(buf: &'de [u8]) -> Self {
+        Self { buf, bytepos: 0 }
+    }
+
+    /// Instantiate an RLP decoder with an input slice and starting byte position.
+    #[inline]
+    pub const fn with_bytepos(buf: &'de [u8], bytepos: usize) -> Self {
+        Self { buf, bytepos }
+    }
+
+    /// Returns the remaining undecoded input.
+    #[inline]
+    pub const fn as_slice(&self) -> &'de [u8] {
+        self.buf
+    }
+
+    /// Returns true if the decoder has no remaining input.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
+    /// Returns the current byte position.
+    #[inline]
+    pub const fn bytepos(&self) -> usize {
+        self.bytepos
+    }
+
+    /// Creates an error at the current byte position.
+    #[inline]
+    pub const fn error(&self, kind: ErrorKind) -> Error {
+        Error::with_bytepos(kind, self.bytepos)
+    }
+
+    /// Creates an error at the given byte position.
+    #[inline]
+    pub const fn error_at(&self, kind: ErrorKind, bytepos: usize) -> Error {
+        Error::with_bytepos(kind, bytepos)
+    }
+
+    /// Decodes the next RLP header, advancing past the header but not the payload.
+    #[inline]
+    pub fn decode_header(&mut self) -> Result<Header> {
+        let before = self.buf.len();
+        match Header::decode(&mut self.buf) {
+            Ok(header) => {
+                self.advance_bytepos(before);
+                Ok(header)
+            }
+            Err(err) => {
+                let err = self.map_error(before, err);
+                self.advance_bytepos(before);
+                Err(err)
+            }
+        }
+    }
+
+    /// Decodes the next payload from the buffer, advancing past the full item.
+    #[inline]
+    pub fn decode_bytes(&mut self, is_list: bool) -> Result<&'de [u8]> {
+        let item_start = self.bytepos;
+        let Header { list, payload_length } = self.decode_header()?;
+
+        if list != is_list {
+            return Err(Error::with_bytepos(
+                if is_list { ErrorKind::UnexpectedString } else { ErrorKind::UnexpectedList },
+                item_start,
+            ));
+        }
+
+        if self.buf.len() < payload_length {
+            return Err(self.error(ErrorKind::InputTooShort));
+        }
+
+        let (payload, rest) = self.buf.split_at(payload_length);
+        self.buf = rest;
+        self.bytepos = self.bytepos.saturating_add(payload_length);
+        Ok(payload)
+    }
+
+    /// Decodes a string slice from the buffer, advancing past the full item.
+    #[inline]
+    pub fn decode_str(&mut self) -> Result<&'de str> {
+        let item_start = self.bytepos;
+        let bytes = self.decode_bytes(false)?;
+        core::str::from_utf8(bytes)
+            .map_err(|_| Error::with_bytepos(ErrorKind::Custom("invalid string"), item_start))
+    }
+
+    /// Decodes the next item using [`RlpDecodable::rlp_decode`].
+    #[inline]
+    pub fn decode_next<T: RlpDecodable>(&mut self) -> Result<T> {
+        self.decode_with(T::rlp_decode)
+    }
+
+    /// Decodes the next item using [`RlpDecodable::rlp_decode_raw`].
+    #[inline]
+    pub fn decode_next_raw<T: RlpDecodable>(&mut self) -> Result<T> {
+        self.decode_with(T::rlp_decode_raw)
+    }
+
+    #[inline]
+    fn decode_with<T>(&mut self, f: impl FnOnce(&mut &'de [u8]) -> Result<T>) -> Result<T> {
+        let before = self.buf.len();
+        match f(&mut self.buf) {
+            Ok(value) => {
+                self.advance_bytepos(before);
+                Ok(value)
+            }
+            Err(err) => {
+                let err = self.map_error(before, err);
+                self.advance_bytepos(before);
+                Err(err)
+            }
+        }
+    }
+
+    #[inline]
+    fn advance_bytepos(&mut self, before: usize) {
+        self.bytepos = self.bytepos.saturating_add(before.saturating_sub(self.buf.len()));
+    }
+
+    #[inline]
+    const fn map_error(&self, before: usize, err: Error) -> Error {
+        let relative = before.saturating_sub(self.buf.len()).saturating_add(err.bytepos());
+        Error::with_bytepos(err.kind(), self.bytepos.saturating_add(relative))
+    }
 }
 
 /// An active RLP decoder, with a specific slice of a payload.
@@ -110,6 +258,51 @@ impl<T: RlpDecodable> RlpDecodable for alloc::vec::Vec<T> {
         }
         Ok(vec)
     }
+}
+
+macro_rules! tuple_impls {
+    ($(($($ty:ident),+)),+ $(,)?) => {$(
+        impl<$($ty: RlpDecodable),+> RlpDecodable for ($($ty,)+) {
+            #[inline]
+            fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
+                let mut payload = Header::decode_bytes(buf, true)?;
+                let started_len = payload.len();
+
+                let this = Self::rlp_decode_raw(&mut payload)?;
+
+                let consumed = started_len - payload.len();
+                if consumed != started_len {
+                    return Err(ErrorKind::ListLengthMismatch {
+                        expected: started_len,
+                        got: consumed,
+                    }
+                    .into());
+                }
+
+                Ok(this)
+            }
+
+            #[inline]
+            fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
+                Ok(($(<$ty as RlpDecodable>::rlp_decode(buf)?,)+))
+            }
+        }
+    )+};
+}
+
+tuple_impls! {
+    (A),
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+    (A, B, C, D, E, F, G, H, I),
+    (A, B, C, D, E, F, G, H, I, J),
+    (A, B, C, D, E, F, G, H, I, J, K),
+    (A, B, C, D, E, F, G, H, I, J, K, L),
 }
 
 macro_rules! wrap_impl {
@@ -399,5 +592,49 @@ mod tests {
         check_decode_exact::<String>("test1234".into());
         check_decode_exact::<Vec<u64>>(vec![]);
         check_decode_exact::<Vec<u64>>(vec![0; 4]);
+    }
+
+    #[test]
+    fn decoder_advances_bytepos() {
+        let mut input = Vec::new();
+        1u8.rlp_encode(&mut crate::Encoder::new(&mut input));
+        "cat".rlp_encode(&mut crate::Encoder::new(&mut input));
+
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        assert_eq!(decoder.bytepos(), 1);
+        assert_eq!(decoder.decode_str(), Ok("cat"));
+        assert_eq!(decoder.bytepos(), input.len());
+        assert!(decoder.is_empty());
+    }
+
+    #[test]
+    fn decoder_reports_error_bytepos() {
+        let input = [0x01, 0xC0];
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        let err = decoder.decode_bytes(false).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedList);
+        assert_eq!(err.bytepos(), 1);
+
+        let input = [0x01, 0x82];
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        let err = decoder.decode_next::<u16>().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InputTooShort);
+        assert_eq!(err.bytepos(), 2);
+    }
+
+    #[test]
+    fn decoder_decode_next_raw() {
+        let mut input = Vec::new();
+        (1u8, 2u8).rlp_encode_raw(&mut crate::Encoder::new(&mut input));
+        3u8.rlp_encode(&mut crate::Encoder::new(&mut input));
+
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next_raw::<(u8, u8)>(), Ok((1, 2)));
+        assert_eq!(decoder.bytepos(), 2);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(3));
+        assert!(decoder.is_empty());
     }
 }

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -47,6 +47,15 @@ pub trait RlpEncodable {
     /// Encodes the type into the `out` buffer.
     fn rlp_encode(&self, out: &mut Encoder<'_>);
 
+    /// Encodes this value without its outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by encoding the value normally.
+    /// Structured implementations may override this to emit their fields sequentially.
+    #[inline]
+    fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+        self.rlp_encode(out);
+    }
+
     /// Returns the length of the encoding of this type in bytes.
     ///
     /// The default implementation computes this by encoding the type.
@@ -57,6 +66,15 @@ pub trait RlpEncodable {
         let mut out = Vec::new();
         self.rlp_encode(&mut Encoder::new(&mut out));
         out.len()
+    }
+
+    /// Returns the length of this value when encoded without its outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by returning the normal encoded
+    /// length. Structured implementations may override this to return only their payload length.
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -237,6 +255,49 @@ impl<T: RlpEncodable> RlpEncodable for Vec<T> {
     }
 }
 
+macro_rules! tuple_impls {
+    ($(($($ty:ident $idx:tt),+)),+ $(,)?) => {$(
+        impl<$($ty: RlpEncodable),+> RlpEncodable for ($($ty,)+) {
+            #[inline]
+            fn rlp_len(&self) -> usize {
+                let payload_length = self.rlp_len_raw();
+                payload_length + length_of_length(payload_length)
+            }
+
+            #[inline]
+            fn rlp_encode(&self, out: &mut Encoder<'_>) {
+                Header { list: true, payload_length: self.rlp_len_raw() }.encode(out);
+                self.rlp_encode_raw(out);
+            }
+
+            #[inline]
+            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+                $(RlpEncodable::rlp_encode(&self.$idx, out);)+
+            }
+
+            #[inline]
+            fn rlp_len_raw(&self) -> usize {
+                0usize $(+ RlpEncodable::rlp_len(&self.$idx))+
+            }
+        }
+    )+};
+}
+
+tuple_impls! {
+    (A 0),
+    (A 0, B 1),
+    (A 0, B 1, C 2),
+    (A 0, B 1, C 2, D 3),
+    (A 0, B 1, C 2, D 3, E 4),
+    (A 0, B 1, C 2, D 3, E 4, F 5),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11),
+}
+
 macro_rules! deref_impl {
     ($($(#[$attr:meta])* [$($gen:tt)*] $t:ty),+ $(,)?) => {$(
         $(#[$attr])*
@@ -249,6 +310,16 @@ macro_rules! deref_impl {
             #[inline]
             fn rlp_encode(&self, out: &mut Encoder<'_>) {
                 (**self).rlp_encode(out)
+            }
+
+            #[inline]
+            fn rlp_len_raw(&self) -> usize {
+                (**self).rlp_len_raw()
+            }
+
+            #[inline]
+            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+                (**self).rlp_encode_raw(out)
             }
         }
     )+};

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -4,12 +4,10 @@ use core::fmt;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// RLP error with byte position context.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
-    /// The byte position in the input where the error occurred.
-    pub bytepos: usize,
-    /// The kind of error.
-    pub kind: ErrorKind,
+    bytepos: usize,
+    kind: ErrorKind,
 }
 
 impl Error {
@@ -23,6 +21,18 @@ impl Error {
     #[inline]
     pub const fn with_bytepos(kind: ErrorKind, bytepos: usize) -> Self {
         Self { bytepos, kind }
+    }
+
+    /// Returns the kind of error.
+    #[inline]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Returns the byte position in the input where the error occurred.
+    #[inline]
+    pub const fn bytepos(&self) -> usize {
+        self.bytepos
     }
 }
 
@@ -106,22 +116,22 @@ mod tests {
     #[test]
     fn error_new() {
         let e = Error::new(ErrorKind::Overflow);
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::Overflow);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::Overflow);
     }
 
     #[test]
     fn error_with_bytepos() {
         let e = Error::with_bytepos(ErrorKind::InputTooShort, 42);
-        assert_eq!(e.bytepos, 42);
-        assert_eq!(e.kind, ErrorKind::InputTooShort);
+        assert_eq!(e.bytepos(), 42);
+        assert_eq!(e.kind(), ErrorKind::InputTooShort);
     }
 
     #[test]
     fn error_from_error_kind() {
         let e: Error = ErrorKind::LeadingZero.into();
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::LeadingZero);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::LeadingZero);
     }
 
     #[test]
@@ -150,11 +160,9 @@ mod tests {
     }
 
     #[test]
-    fn error_clone_copy() {
+    fn error_clone() {
         let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
-        let cloned = e;
-        let copied = e;
+        let cloned = e.clone();
         assert_eq!(e, cloned);
-        assert_eq!(e, copied);
     }
 }

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{decode_exact, Rlp, RlpDecodable};
+pub use decode::{decode_exact, Decoder, Rlp, RlpDecodable};
 
 mod error;
 pub use error::{Error, ErrorKind, Result};

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -5,6 +5,13 @@
 
 use alloy_rlp::*;
 
+fn assert_err_kind<T>(result: alloy_rlp::Result<T>, expected: ErrorKind) {
+    match result {
+        Ok(_) => panic!("expected {expected:?} error"),
+        Err(err) => assert_eq!(err.kind(), expected),
+    }
+}
+
 #[test]
 fn simple_derive() {
     #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
@@ -134,4 +141,358 @@ fn skip_field() {
 
     let decoded = WithoutSkip::rlp_decode(&mut buf.as_slice()).unwrap();
     assert_eq!(decoded.value, 42);
+}
+
+#[test]
+fn tuple_roundtrips_and_raw_modes() {
+    fn check<T>(value: T)
+    where
+        T: RlpEncodable + RlpDecodable + PartialEq + std::fmt::Debug,
+    {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(encoded.len(), value.rlp_len());
+        let decoded = T::rlp_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded, value);
+
+        let mut raw = Vec::new();
+        value.rlp_encode_raw(&mut Encoder::new(&mut raw));
+        assert_eq!(raw.len(), value.rlp_len_raw());
+        let mut raw_slice = raw.as_slice();
+        let decoded_raw = T::rlp_decode_raw(&mut raw_slice).unwrap();
+        assert_eq!(decoded_raw, value);
+        assert!(raw_slice.is_empty());
+        assert_ne!(encoded, raw);
+    }
+
+    check((1u8,));
+    check((1u8, 2u16));
+    check((1u8, 2u16, 3u32));
+    check((1u8, 2u16, 3u32, 4u64));
+    check((1u8, 2u16, 3u32, 4u64, 5usize));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1]));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1], [8u8; 2]));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1], [8u8; 2], String::from("nine")));
+    check((
+        1u8,
+        2u16,
+        3u32,
+        4u64,
+        5usize,
+        6u128,
+        true,
+        [7u8; 1],
+        [8u8; 2],
+        String::from("nine"),
+        Bytes::from(vec![10u8]),
+    ));
+    check((
+        1u8,
+        2u16,
+        3u32,
+        4u64,
+        5usize,
+        6u128,
+        true,
+        [7u8; 1],
+        [8u8; 2],
+        String::from("nine"),
+        Bytes::from(vec![10u8]),
+        BytesMut::from(&b"eleven"[..]),
+    ));
+}
+
+#[test]
+fn tuple_decode_rejects_malformed_lists() {
+    let too_few = alloy_rlp::encode((1u8,));
+    assert_err_kind(<(u8, u8)>::rlp_decode(&mut too_few.as_slice()), ErrorKind::InputTooShort);
+
+    let extra = alloy_rlp::encode((1u8, 2u8));
+    assert_err_kind(
+        <(u8,)>::rlp_decode(&mut extra.as_slice()),
+        ErrorKind::ListLengthMismatch { expected: 2, got: 1 },
+    );
+
+    assert_err_kind(<(u8,)>::rlp_decode(&mut [0x01].as_slice()), ErrorKind::UnexpectedString);
+}
+
+#[test]
+fn tuple_raw_decode_leaves_outer_fields() {
+    let mut raw = Vec::new();
+    (1u8, 2u8).rlp_encode_raw(&mut Encoder::new(&mut raw));
+    3u8.rlp_encode(&mut Encoder::new(&mut raw));
+
+    let mut slice = raw.as_slice();
+    let tuple = <(u8, u8)>::rlp_decode_raw(&mut slice).unwrap();
+    let tail = u8::rlp_decode(&mut slice).unwrap();
+    assert_eq!(tuple, (1, 2));
+    assert_eq!(tail, 3);
+    assert!(slice.is_empty());
+}
+
+#[test]
+fn flatten_nested_vs_flat_encoding() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+        b: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterNested {
+        x: u64,
+        inner: Inner,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterFlat {
+        x: u64,
+        #[rlp(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Equivalent {
+        x: u64,
+        a: u64,
+        b: u64,
+    }
+
+    let nested = OuterNested { x: 1, inner: Inner { a: 2, b: 3 } };
+    let flat = OuterFlat { x: 1, inner: Inner { a: 2, b: 3 } };
+    let equivalent = Equivalent { x: 1, a: 2, b: 3 };
+
+    let nested_encoded = alloy_rlp::encode(&nested);
+    let flat_encoded = alloy_rlp::encode(&flat);
+    assert_ne!(nested_encoded, flat_encoded);
+    assert_eq!(flat_encoded, alloy_rlp::encode(&equivalent));
+    assert_eq!(OuterFlat::rlp_decode(&mut flat_encoded.as_slice()).unwrap(), flat);
+}
+
+#[test]
+fn flatten_multiple_and_tuple_fields() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct A {
+        x: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct B {
+        y: u16,
+        z: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Combined {
+        #[rlp(flatten)]
+        a: A,
+        #[rlp(flatten)]
+        pair: (u8, u16),
+        #[rlp(flatten)]
+        b: B,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        x: u64,
+        pair_0: u8,
+        pair_1: u16,
+        y: u16,
+        z: u64,
+    }
+
+    let value = Combined { a: A { x: 10 }, pair: (11, 12), b: B { y: 20, z: 30 } };
+    let flat = Flat { x: 10, pair_0: 11, pair_1: 12, y: 20, z: 30 };
+
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&flat));
+    assert_eq!(Combined::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+}
+
+#[test]
+fn flatten_with_skip_default_fields() {
+    #[derive(PartialEq, Debug, Default)]
+    struct Cache(u64);
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+        #[rlp(default, skip)]
+        cache: Cache,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Outer {
+        #[rlp(flatten)]
+        inner: Inner,
+        b: u64,
+        #[rlp(skip)]
+        cache: Cache,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        a: u64,
+        b: u64,
+    }
+
+    let value = Outer { inner: Inner { a: 1, cache: Cache(2) }, b: 3, cache: Cache(4) };
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, b: 3 }));
+
+    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded.inner.a, 1);
+    assert_eq!(decoded.inner.cache, Cache::default());
+    assert_eq!(decoded.b, 3);
+    assert_eq!(decoded.cache, Cache::default());
+}
+
+#[test]
+fn trailing_optional_last_field_roundtrips_zero() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing)]
+    struct S {
+        x: u64,
+        y: Option<u64>,
+    }
+
+    for value in [S { x: 1, y: None }, S { x: 1, y: Some(0) }, S { x: 1, y: Some(2) }] {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(S::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+    }
+}
+
+#[test]
+fn flattened_trailing_options_do_not_consume_outer_fields() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing)]
+    struct Inner {
+        a: u64,
+        maybe: Option<u64>,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Outer {
+        #[rlp(flatten)]
+        inner: Inner,
+        tail: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        a: u64,
+        tail: u64,
+    }
+
+    let value = Outer { inner: Inner { a: 1, maybe: Some(2) }, tail: 3 };
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, tail: 3 }));
+
+    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, Outer { inner: Inner { a: 1, maybe: None }, tail: 3 });
+}
+
+#[test]
+fn tagged_enum_roundtrips_shapes_and_tags() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Message {
+        Ping,
+        Pong(u8, u16),
+        Data { a: u8, b: u64 },
+    }
+
+    for value in [Message::Ping, Message::Pong(1, 2), Message::Data { a: 3, b: 4 }] {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(Message::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Discriminants {
+        Start = 10,
+        Stop = 20,
+    }
+
+    assert_eq!(alloy_rlp::encode(&Discriminants::Start), alloy_rlp::encode((10u64,)));
+    assert_eq!(alloy_rlp::encode(&Discriminants::Stop), alloy_rlp::encode((20u64,)));
+    assert_eq!(
+        Discriminants::rlp_decode(&mut alloy_rlp::encode((10u64,)).as_slice()).unwrap(),
+        Discriminants::Start
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Custom {
+        #[rlp(tag = 0x80)]
+        Alpha,
+        #[rlp(tag = 0x1234)]
+        Beta(u64),
+    }
+
+    assert_eq!(alloy_rlp::encode(&Custom::Alpha), alloy_rlp::encode((0x80u64,)));
+    let beta = Custom::Beta(99);
+    let encoded = alloy_rlp::encode(&beta);
+    assert_eq!(Custom::rlp_decode(&mut encoded.as_slice()).unwrap(), beta);
+}
+
+#[test]
+fn tagged_enum_rejects_unknown_tags_and_trailing_payload() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Command {
+        Start = 10,
+    }
+
+    assert_err_kind(
+        Command::rlp_decode(&mut alloy_rlp::encode((99u64,)).as_slice()),
+        ErrorKind::Custom("unknown variant tag"),
+    );
+    assert_err_kind(
+        Command::rlp_decode(&mut alloy_rlp::encode((10u64, 1u8)).as_slice()),
+        ErrorKind::ListLengthMismatch { expected: 0, got: 1 },
+    );
+}
+
+#[test]
+fn transparent_structs_encode_as_inner_field() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Named {
+        inner: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Newtype(u64);
+
+    #[derive(PartialEq, Debug, Default)]
+    struct Marker;
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct WithSkip {
+        value: u64,
+        #[rlp(skip)]
+        marker: Marker,
+    }
+
+    for encoded in [
+        alloy_rlp::encode(Named { inner: 42 }),
+        alloy_rlp::encode(Newtype(42)),
+        alloy_rlp::encode(WithSkip { value: 42, marker: Marker }),
+    ] {
+        assert_eq!(encoded, alloy_rlp::encode(42u64));
+    }
+
+    assert_eq!(
+        Named::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
+        Named { inner: 42 }
+    );
+    assert_eq!(Newtype::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(), Newtype(42));
+    assert_eq!(
+        WithSkip::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
+        WithSkip { value: 42, marker: Marker }
+    );
 }


### PR DESCRIPTION
Progresses #14.

## Summary
- Adds compatible raw RLP trait APIs (`rlp_encode_raw`, `rlp_len_raw`, `rlp_decode_raw`) and overrides derived structs/tuples so raw mode omits the outer list header.
- Implements tuple `RlpEncodable`/`RlpDecodable` for arities 1 through 12, with normal list mode and raw sequential mode.
- Adds `#[rlp(flatten)]`, `#[rlp(tagged)]`, and `#[rlp(transparent)]` derive support while keeping the existing wrapper derives.
- Makes `Error` non-`Copy` with private fields plus `kind()`/`bytepos()` getters, and adds a position-aware `Decoder` helper API.
- Adds runtime and doc compile-fail coverage for tuple, flatten, tagged enum, transparent, and decoder/error behavior.
