### PR TITLE
Require rlp_len_raw and modernize Decoder/Encoder APIs

### DIFF
--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -331,10 +331,14 @@ pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStrea
                 #[inline]
                 fn rlp_decode(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
                     let mut payload = decoder.decode_payload(true)?;
+                    let tag_bytepos = payload.bytepos();
                     let tag = <u64 as alloy_rlp::RlpDecodable<'__alloy_rlp_de>>::rlp_decode(&mut payload)?;
                     let value = match tag {
                         #(#match_arms)*
-                        _ => alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::Custom("unknown variant tag"))),
+                        _ => alloy_rlp::private::Err(alloy_rlp::Error::with_bytepos(
+                            alloy_rlp::ErrorKind::Custom("unknown variant tag"),
+                            tag_bytepos,
+                        )),
                     }?;
                     if !payload.is_empty() {
                         return alloy_rlp::private::Err(payload.error(alloy_rlp::ErrorKind::ListLengthMismatch {

--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -1,20 +1,49 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Error, Result};
 
 pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    if attributes_include(&ast.attrs, "tagged") {
+        return impl_decodable_tagged(ast);
+    }
+    if matches!(ast.data, syn::Data::Enum(_)) {
+        let msg = "RLP enum derives require `#[rlp(tagged)]`";
+        return Err(Error::new_spanned(ast, msg));
+    }
+
     let body = parse_struct(ast, "RlpDecodable")?;
 
-    let fields = body.fields.iter().enumerate();
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_decodable_transparent(ast, body);
+    }
+
+    let all_fields: Vec<_> = body.fields.iter().enumerate().collect();
 
     let supports_trailing_opt = attributes_include(&ast.attrs, "trailing");
 
+    let last_consuming_idx = all_fields
+        .iter()
+        .rev()
+        .find(|(_, field)| {
+            !attributes_include(&field.attrs, "skip")
+                && !attributes_include(&field.attrs, "default")
+        })
+        .map(|(i, _)| *i);
+
     let mut encountered_opt_item = false;
     let mut decode_stmts = Vec::with_capacity(body.fields.len());
-    for (i, field) in fields {
+    let mut decode_stmts_raw = Vec::with_capacity(body.fields.len());
+    for &(i, field) in &all_fields {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -28,7 +57,9 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
             return Err(Error::new_spanned(field, msg));
         }
 
-        decode_stmts.push(decodable_field(i, field, is_opt));
+        let is_last_consuming = last_consuming_idx == Some(i);
+        decode_stmts.push(decodable_field(i, field, is_opt, is_last_consuming));
+        decode_stmts_raw.push(decodable_field_raw(i, field));
     }
 
     let name = &ast.ident;
@@ -66,6 +97,84 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
                     Ok(this)
                 }
+
+                #[inline]
+                fn rlp_decode_raw(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    Ok(Self {
+                        #(#decode_stmts_raw)*
+                    })
+                }
+            }
+        };
+    })
+}
+
+fn impl_decodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let field_inits: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let ident = field_ident(i, field);
+            if attributes_include(&field.attrs, "skip") {
+                quote! { #ident: alloy_rlp::private::Default::default(), }
+            } else {
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(buf)?, }
+            }
+        })
+        .collect();
+
+    let field_inits_raw: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let ident = field_ident(i, field);
+            if attributes_include(&field.attrs, "skip") {
+                quote! { #ident: alloy_rlp::private::Default::default(), }
+            } else {
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(buf)?, }
+            }
+        })
+        .collect();
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::Ok(Self {
+                        #(#field_inits)*
+                    })
+                }
+
+                #[inline]
+                fn rlp_decode_raw(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::Ok(Self {
+                        #(#field_inits_raw)*
+                    })
+                }
             }
         };
     })
@@ -97,25 +206,131 @@ pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStre
     })
 }
 
-fn decodable_field(index: usize, field: &syn::Field, is_opt: bool) -> TokenStream {
+fn decodable_field(
+    index: usize,
+    field: &syn::Field,
+    is_opt: bool,
+    is_last_consuming: bool,
+) -> TokenStream {
     let ident = field_ident(index, field);
 
-    if attributes_include(&field.attrs, "default") {
+    if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
         quote! { #ident: alloy_rlp::private::Default::default(), }
     } else if is_opt {
-        quote! {
-            #ident: if started_len - b.len() < payload_length {
-                if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
-                    alloy_rlp::Buf::advance(b, 1);
-                    None
-                } else {
+        if is_last_consuming {
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
                     Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
-                }
-            } else {
-                None
-            },
+                } else {
+                    None
+                },
+            }
+        } else {
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
+                    if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
+                        alloy_rlp::Buf::advance(b, 1);
+                        None
+                    } else {
+                        Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
+                    }
+                } else {
+                    None
+                },
+            }
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
     } else {
         quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
     }
+}
+
+fn decodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
+        quote! { #ident: alloy_rlp::private::Default::default(), }
+    } else if is_optional(field) {
+        quote! { #ident: alloy_rlp::private::None, }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
+    } else {
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
+    }
+}
+
+pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpDecodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+        let tag_expr = variant_tag_expr(i, variant)?;
+
+        let construct = match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_decodes = fields.named.iter().map(|f| {
+                    let fname = f.ident.as_ref().unwrap();
+                    quote! { #fname: alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? }
+                });
+                quote! { #name::#var_ident { #(#field_decodes),* } }
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_decodes = (0..fields.unnamed.len())
+                    .map(|_| quote! { alloy_rlp::RlpDecodable::rlp_decode(&mut payload)? });
+                quote! { #name::#var_ident(#(#field_decodes),*) }
+            }
+            syn::Fields::Unit => quote! { #name::#var_ident },
+        };
+
+        match_arms.push(quote! {
+            tag if tag == (#tag_expr) as u64 => alloy_rlp::private::Ok(#construct),
+        });
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    let mut payload = alloy_rlp::Header::decode_bytes(b, true)?;
+                    let tag = <u64 as alloy_rlp::RlpDecodable>::rlp_decode(&mut payload)?;
+                    let value = match tag {
+                        #(#match_arms)*
+                        _ => alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::Custom("unknown variant tag"))),
+                    }?;
+                    if !payload.is_empty() {
+                        return alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::ListLengthMismatch {
+                            expected: 0,
+                            got: payload.len(),
+                        }));
+                    }
+                    alloy_rlp::private::Ok(value)
+                }
+            }
+        };
+    })
+}
+
+fn variant_tag_expr(index: usize, variant: &syn::Variant) -> Result<TokenStream> {
+    Ok(get_tag_value(&variant.attrs)?.map_or_else(
+        || {
+            variant.discriminant.as_ref().map_or_else(
+                || {
+                    let index = index as u64;
+                    quote! { #index }
+                },
+                |(_, expr)| quote! { #expr },
+            )
+        },
+        |expr| quote! { #expr },
+    ))
 }

--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
-    parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, option_inner_type,
+    parse_enum, parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -37,6 +37,7 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let mut encountered_opt_item = false;
     let mut decode_stmts = Vec::with_capacity(body.fields.len());
     let mut decode_stmts_raw = Vec::with_capacity(body.fields.len());
+    let mut min_raw_item_exprs = Vec::with_capacity(body.fields.len());
     for &(i, field) in &all_fields {
         let is_flatten = attributes_include(&field.attrs, "flatten");
         if is_flatten && is_optional(field) {
@@ -57,49 +58,49 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
             return Err(Error::new_spanned(field, msg));
         }
 
+        let tail_items = min_raw_items_from(all_fields.iter().copied().filter(|(j, _)| *j > i));
         let is_last_consuming = last_consuming_idx == Some(i);
-        decode_stmts.push(decodable_field(i, field, is_opt, is_last_consuming));
-        decode_stmts_raw.push(decodable_field_raw(i, field));
+        decode_stmts.push(decodable_field(i, field, is_opt, is_last_consuming, &tail_items));
+        decode_stmts_raw.push(decodable_field_raw(i, field, &tail_items));
+        if let Some(expr) = min_raw_items_field(field) {
+            min_raw_item_exprs.push(expr);
+        }
     }
 
     let name = &ast.ident;
-    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let generics = make_decode_generics(&ast.generics);
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     Ok(quote! {
         const _: () = {
             extern crate alloy_rlp;
 
-            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
-                #[inline]
-                fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
-                    let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(b)?;
-                    if !list {
-                        return Err(alloy_rlp::ErrorKind::UnexpectedString.into());
-                    }
+            impl #impl_generics alloy_rlp::RlpDecodable<'__alloy_rlp_de> for #name #ty_generics #where_clause {
+                const MIN_RAW_ITEMS: usize = 0usize #( + #min_raw_item_exprs)*;
 
+                #[inline]
+                fn rlp_decode(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
+                    let mut b = decoder.decode_payload(true)?;
                     let started_len = b.len();
-                    if started_len < payload_length {
-                        return Err(alloy_rlp::ErrorKind::InputTooShort.into());
-                    }
 
                     let this = Self {
                         #(#decode_stmts)*
                     };
 
-                    let consumed = started_len - b.len();
-                    if consumed != payload_length {
-                        return Err(alloy_rlp::ErrorKind::ListLengthMismatch {
-                            expected: payload_length,
+                    let consumed = started_len.saturating_sub(b.len());
+                    if consumed != started_len {
+                        return Err(b.error(alloy_rlp::ErrorKind::ListLengthMismatch {
+                            expected: started_len,
                             got: consumed,
-                        }.into());
+                        }));
                     }
 
                     Ok(this)
                 }
 
                 #[inline]
-                fn rlp_decode_raw(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                fn rlp_decode_raw(b: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
                     Ok(Self {
                         #(#decode_stmts_raw)*
                     })
@@ -125,6 +126,9 @@ fn impl_decodable_transparent(
         return Err(Error::new(ast.ident.span(), msg));
     }
 
+    let (_, non_skipped_field) = non_skipped[0];
+    let non_skipped_ty = &non_skipped_field.ty;
+
     let field_inits: Vec<_> = body
         .fields
         .iter()
@@ -134,7 +138,7 @@ fn impl_decodable_transparent(
             if attributes_include(&field.attrs, "skip") {
                 quote! { #ident: alloy_rlp::private::Default::default(), }
             } else {
-                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(buf)?, }
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(decoder)?, }
             }
         })
         .collect();
@@ -148,29 +152,32 @@ fn impl_decodable_transparent(
             if attributes_include(&field.attrs, "skip") {
                 quote! { #ident: alloy_rlp::private::Default::default(), }
             } else {
-                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(buf)?, }
+                quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(decoder)?, }
             }
         })
         .collect();
 
     let name = &ast.ident;
-    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let generics = make_decode_generics(&ast.generics);
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     Ok(quote! {
         const _: () = {
             extern crate alloy_rlp;
 
-            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+            impl #impl_generics alloy_rlp::RlpDecodable<'__alloy_rlp_de> for #name #ty_generics #where_clause {
+                const MIN_RAW_ITEMS: usize = <#non_skipped_ty as alloy_rlp::RlpDecodable<'__alloy_rlp_de>>::MIN_RAW_ITEMS;
+
                 #[inline]
-                fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                fn rlp_decode(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
                     alloy_rlp::private::Result::Ok(Self {
                         #(#field_inits)*
                     })
                 }
 
                 #[inline]
-                fn rlp_decode_raw(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                fn rlp_decode_raw(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
                     alloy_rlp::private::Result::Ok(Self {
                         #(#field_inits_raw)*
                     })
@@ -189,17 +196,26 @@ pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStre
     }
 
     let name = &ast.ident;
-    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let field_ty = body.fields.iter().next().map(|field| &field.ty).unwrap();
+    let generics = make_decode_generics(&ast.generics);
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     Ok(quote! {
         const _: () = {
             extern crate alloy_rlp;
 
-            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+            impl #impl_generics alloy_rlp::RlpDecodable<'__alloy_rlp_de> for #name #ty_generics #where_clause {
+                const MIN_RAW_ITEMS: usize = <#field_ty as alloy_rlp::RlpDecodable<'__alloy_rlp_de>>::MIN_RAW_ITEMS;
+
                 #[inline]
-                fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-                    alloy_rlp::private::Result::map(alloy_rlp::RlpDecodable::rlp_decode(buf), Self)
+                fn rlp_decode(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::map(alloy_rlp::RlpDecodable::rlp_decode(decoder), Self)
+                }
+
+                #[inline]
+                fn rlp_decode_raw(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
+                    alloy_rlp::private::Result::map(alloy_rlp::RlpDecodable::rlp_decode_raw(decoder), Self)
                 }
             }
         };
@@ -211,6 +227,7 @@ fn decodable_field(
     field: &syn::Field,
     is_opt: bool,
     is_last_consuming: bool,
+    tail_items: &TokenStream,
 ) -> TokenStream {
     let ident = field_ident(index, field);
 
@@ -219,20 +236,20 @@ fn decodable_field(
     } else if is_opt {
         if is_last_consuming {
             quote! {
-                #ident: if started_len - b.len() < payload_length {
-                    Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
+                #ident: if !b.is_empty() {
+                    Some(alloy_rlp::RlpDecodable::rlp_decode(&mut b)?)
                 } else {
                     None
                 },
             }
         } else {
             quote! {
-                #ident: if started_len - b.len() < payload_length {
-                    if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
-                        alloy_rlp::Buf::advance(b, 1);
+                #ident: if !b.is_empty() {
+                    if b.peek() == Some(#EMPTY_STRING_CODE) {
+                        b.advance(1)?;
                         None
                     } else {
-                        Some(alloy_rlp::RlpDecodable::rlp_decode(b)?)
+                        Some(alloy_rlp::RlpDecodable::rlp_decode(&mut b)?)
                     }
                 } else {
                     None
@@ -240,21 +257,32 @@ fn decodable_field(
             }
         }
     } else if attributes_include(&field.attrs, "flatten") {
-        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
+        quote! {
+            #ident: {
+                let raw_tail_items = b.raw_tail_items().saturating_add(#tail_items);
+                b.with_raw_tail_items(raw_tail_items, |b| alloy_rlp::RlpDecodable::rlp_decode_raw(b))?
+            },
+        }
     } else {
-        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
+        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(&mut b)?, }
     }
 }
 
-fn decodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+fn decodable_field_raw(index: usize, field: &syn::Field, tail_items: &TokenStream) -> TokenStream {
     let ident = field_ident(index, field);
 
     if attributes_include(&field.attrs, "default") || attributes_include(&field.attrs, "skip") {
         quote! { #ident: alloy_rlp::private::Default::default(), }
     } else if is_optional(field) {
-        quote! { #ident: alloy_rlp::private::None, }
+        let inner_ty = option_inner_type(field).expect("checked optional field");
+        quote! { #ident: alloy_rlp::private::decode_optional_raw::<#inner_ty>(b, #tail_items)?, }
     } else if attributes_include(&field.attrs, "flatten") {
-        quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode_raw(b)?, }
+        quote! {
+            #ident: {
+                let raw_tail_items = b.raw_tail_items().saturating_add(#tail_items);
+                b.with_raw_tail_items(raw_tail_items, |b| alloy_rlp::RlpDecodable::rlp_decode_raw(b))?
+            },
+        }
     } else {
         quote! { #ident: alloy_rlp::RlpDecodable::rlp_decode(b)?, }
     }
@@ -264,8 +292,9 @@ pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStrea
     let body = parse_enum(ast, "RlpDecodable")?;
 
     let name = &ast.ident;
-    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpDecodable));
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let generics = make_decode_generics(&ast.generics);
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     let mut match_arms = Vec::new();
 
@@ -298,17 +327,17 @@ pub(crate) fn impl_decodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStrea
         const _: () = {
             extern crate alloy_rlp;
 
-            impl #impl_generics alloy_rlp::RlpDecodable for #name #ty_generics #where_clause {
+            impl #impl_generics alloy_rlp::RlpDecodable<'__alloy_rlp_de> for #name #ty_generics #where_clause {
                 #[inline]
-                fn rlp_decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
-                    let mut payload = alloy_rlp::Header::decode_bytes(b, true)?;
-                    let tag = <u64 as alloy_rlp::RlpDecodable>::rlp_decode(&mut payload)?;
+                fn rlp_decode(decoder: &mut alloy_rlp::Decoder<'__alloy_rlp_de>) -> alloy_rlp::Result<Self> {
+                    let mut payload = decoder.decode_payload(true)?;
+                    let tag = <u64 as alloy_rlp::RlpDecodable<'__alloy_rlp_de>>::rlp_decode(&mut payload)?;
                     let value = match tag {
                         #(#match_arms)*
                         _ => alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::Custom("unknown variant tag"))),
                     }?;
                     if !payload.is_empty() {
-                        return alloy_rlp::private::Err(alloy_rlp::Error::from(alloy_rlp::ErrorKind::ListLengthMismatch {
+                        return alloy_rlp::private::Err(payload.error(alloy_rlp::ErrorKind::ListLengthMismatch {
                             expected: 0,
                             got: payload.len(),
                         }));
@@ -333,4 +362,29 @@ fn variant_tag_expr(index: usize, variant: &syn::Variant) -> Result<TokenStream>
         },
         |expr| quote! { #expr },
     ))
+}
+
+fn make_decode_generics(generics: &syn::Generics) -> syn::Generics {
+    let mut generics = make_generics(generics, quote!(alloy_rlp::RlpDecodable<'__alloy_rlp_de>));
+    generics.params.insert(0, syn::parse_quote!('__alloy_rlp_de));
+    generics
+}
+
+fn min_raw_items_from<'a>(fields: impl Iterator<Item = (usize, &'a syn::Field)>) -> TokenStream {
+    let exprs = fields.filter_map(|(_, field)| min_raw_items_field(field));
+    quote! { 0usize #( + #exprs)* }
+}
+
+fn min_raw_items_field(field: &syn::Field) -> Option<TokenStream> {
+    if attributes_include(&field.attrs, "default")
+        || attributes_include(&field.attrs, "skip")
+        || is_optional(field)
+    {
+        None
+    } else if attributes_include(&field.attrs, "flatten") {
+        let ty = &field.ty;
+        Some(quote! { <#ty as alloy_rlp::RlpDecodable<'__alloy_rlp_de>>::MIN_RAW_ITEMS })
+    } else {
+        Some(quote! { 1usize })
+    }
 }

--- a/crates/rlp-derive/src/en.rs
+++ b/crates/rlp-derive/src/en.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, get_tag_value, is_optional, make_generics, parse_enum,
+    parse_struct, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -7,7 +8,19 @@ use std::iter::Peekable;
 use syn::{Error, Result};
 
 pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    if attributes_include(&ast.attrs, "tagged") {
+        return impl_encodable_tagged(ast);
+    }
+    if matches!(ast.data, syn::Data::Enum(_)) {
+        let msg = "RLP enum derives require `#[rlp(tagged)]`";
+        return Err(Error::new_spanned(ast, msg));
+    }
+
     let body = parse_struct(ast, "RlpEncodable")?;
+
+    if attributes_include(&ast.attrs, "transparent") {
+        return impl_encodable_transparent(ast, body);
+    }
 
     let mut fields = body
         .fields
@@ -21,8 +34,16 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
     let mut encountered_opt_item = false;
     let mut length_exprs = Vec::with_capacity(body.fields.len());
     let mut encode_exprs = Vec::with_capacity(body.fields.len());
+    let mut length_exprs_raw = Vec::with_capacity(body.fields.len());
+    let mut encode_exprs_raw = Vec::with_capacity(body.fields.len());
 
     while let Some((i, field)) = fields.next() {
+        let is_flatten = attributes_include(&field.attrs, "flatten");
+        if is_flatten && is_optional(field) {
+            let msg = "`#[rlp(flatten)]` cannot be used on `Option<T>` fields";
+            return Err(Error::new_spanned(field, msg));
+        }
+
         let is_opt = is_optional(field);
         if is_opt {
             if !supports_trailing_opt {
@@ -37,6 +58,10 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
         length_exprs.push(encodable_length(i, field, is_opt, fields.clone()));
         encode_exprs.push(encodable_field(i, field, is_opt, fields.clone()));
+        if !is_opt && !attributes_include(&field.attrs, "default") {
+            length_exprs_raw.push(encodable_length_raw(i, field));
+            encode_exprs_raw.push(encodable_field_raw(i, field));
+        }
     }
 
     let name = &ast.ident;
@@ -63,6 +88,16 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                     .encode(out);
                     #(#encode_exprs)*
                 }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    self._alloy_rlp_payload_length_raw()
+                }
+
+                #[inline]
+                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    #(#encode_exprs_raw)*
+                }
             }
 
             impl #impl_generics #name #ty_generics #where_clause {
@@ -70,6 +105,64 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 #[inline]
                 fn _alloy_rlp_payload_length(&self) -> usize {
                     0usize #( + #length_exprs)*
+                }
+
+                #[allow(unused_parens)]
+                #[inline]
+                fn _alloy_rlp_payload_length_raw(&self) -> usize {
+                    0usize #( + #length_exprs_raw)*
+                }
+            }
+        };
+    })
+}
+
+fn impl_encodable_transparent(
+    ast: &syn::DeriveInput,
+    body: &syn::DataStruct,
+) -> Result<TokenStream> {
+    let non_skipped: Vec<_> = body
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
+        .collect();
+
+    if non_skipped.len() != 1 {
+        let msg = "`#[rlp(transparent)]` requires exactly one non-skipped field";
+        return Err(Error::new(ast.ident.span(), msg));
+    }
+
+    let (index, field) = non_skipped[0];
+    let ident = field_ident(index, field);
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out)
+                }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out)
                 }
             }
         };
@@ -175,6 +268,18 @@ fn encodable_length<'a>(
         };
 
         quote! { self.#ident.as_ref().map(|val| alloy_rlp::RlpEncodable::rlp_len(val)).unwrap_or(#default) }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
+    } else {
+        quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
+    }
+}
+
+fn encodable_length_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
     }
@@ -206,6 +311,18 @@ fn encodable_field<'a>(
         } else {
             quote! { #if_some_encode }
         }
+    } else if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
+    } else {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
+    }
+}
+
+fn encodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+    let ident = field_ident(index, field);
+
+    if attributes_include(&field.attrs, "flatten") {
+        quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
     }
@@ -219,4 +336,132 @@ fn remaining_opt_fields_some_condition<'a>(
         quote! { self.#ident.is_some() }
     });
     quote! { #(#conditions)||* }
+}
+
+pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
+    let body = parse_enum(ast, "RlpEncodable")?;
+
+    let name = &ast.ident;
+    let generics = make_generics(&ast.generics, quote!(alloy_rlp::RlpEncodable));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut length_arms = Vec::new();
+    let mut encode_arms = Vec::new();
+
+    for (i, variant) in body.variants.iter().enumerate() {
+        let var_ident = &variant.ident;
+        let tag_expr = variant_tag_expr(i, variant)?;
+
+        match &variant.fields {
+            syn::Fields::Named(fields) => {
+                let field_names: Vec<_> =
+                    fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+
+                let length_fields =
+                    field_names.iter().map(|f| quote! { alloy_rlp::RlpEncodable::rlp_len(#f) });
+                let encode_fields = field_names
+                    .iter()
+                    .map(|f| quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); });
+
+                length_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident { #(ref #field_names),* } => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unnamed(fields) => {
+                let field_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|j| syn::Ident::new(&format!("f{j}"), var_ident.span()))
+                    .collect();
+
+                let length_fields =
+                    field_names.iter().map(|f| quote! { alloy_rlp::RlpEncodable::rlp_len(#f) });
+                let encode_fields = field_names
+                    .iter()
+                    .map(|f| quote! { alloy_rlp::RlpEncodable::rlp_encode(#f, out); });
+
+                length_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag) #(+ #length_fields)*
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident(#(ref #field_names),*) => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                        #(#encode_fields)*
+                    }
+                });
+            }
+            syn::Fields::Unit => {
+                length_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_len(&tag)
+                    }
+                });
+                encode_arms.push(quote! {
+                    #name::#var_ident => {
+                        let tag: u64 = (#tag_expr) as u64;
+                        alloy_rlp::RlpEncodable::rlp_encode(&tag, out);
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(quote! {
+        const _: () = {
+            extern crate alloy_rlp;
+
+            impl #impl_generics alloy_rlp::RlpEncodable for #name #ty_generics #where_clause {
+                #[inline]
+                fn rlp_len(&self) -> usize {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    payload_length + alloy_rlp::length_of_length(payload_length)
+                }
+
+                #[inline]
+                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                    let payload_length = match self {
+                        #(#length_arms)*
+                    };
+                    alloy_rlp::Header {
+                        list: true,
+                        payload_length,
+                    }
+                    .encode(out);
+                    match self {
+                        #(#encode_arms)*
+                    }
+                }
+            }
+        };
+    })
+}
+
+fn variant_tag_expr(index: usize, variant: &syn::Variant) -> Result<TokenStream> {
+    Ok(get_tag_value(&variant.attrs)?.map_or_else(
+        || {
+            variant.discriminant.as_ref().map_or_else(
+                || {
+                    let index = index as u64;
+                    quote! { #index }
+                },
+                |(_, expr)| quote! { #expr },
+            )
+        },
+        |expr| quote! { #expr },
+    ))
 }

--- a/crates/rlp-derive/src/en.rs
+++ b/crates/rlp-derive/src/en.rs
@@ -58,9 +58,9 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
         length_exprs.push(encodable_length(i, field, is_opt, fields.clone()));
         encode_exprs.push(encodable_field(i, field, is_opt, fields.clone()));
-        if !is_opt && !attributes_include(&field.attrs, "default") {
-            length_exprs_raw.push(encodable_length_raw(i, field));
-            encode_exprs_raw.push(encodable_field_raw(i, field));
+        if !attributes_include(&field.attrs, "default") {
+            length_exprs_raw.push(encodable_length_raw(i, field, is_opt, fields.clone()));
+            encode_exprs_raw.push(encodable_field_raw(i, field, is_opt, fields.clone()));
         }
     }
 
@@ -80,7 +80,7 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 }
 
                 #[inline]
-                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     alloy_rlp::Header {
                         list: true,
                         payload_length: self._alloy_rlp_payload_length(),
@@ -95,7 +95,7 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
                 }
 
                 #[inline]
-                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode_raw<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     #(#encode_exprs_raw)*
                 }
             }
@@ -151,7 +151,7 @@ fn impl_encodable_transparent(
                 }
 
                 #[inline]
-                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out)
                 }
 
@@ -161,7 +161,7 @@ fn impl_encodable_transparent(
                 }
 
                 #[inline]
-                fn rlp_encode_raw(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode_raw<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out)
                 }
             }
@@ -197,8 +197,18 @@ pub(crate) fn impl_encodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStre
                 }
 
                 #[inline]
-                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out)
+                }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident)
+                }
+
+                #[inline]
+                fn rlp_encode_raw<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
+                    alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out)
                 }
             }
         };
@@ -275,10 +285,18 @@ fn encodable_length<'a>(
     }
 }
 
-fn encodable_length_raw(index: usize, field: &syn::Field) -> TokenStream {
+fn encodable_length_raw<'a>(
+    index: usize,
+    field: &syn::Field,
+    is_opt: bool,
+    remaining: Peekable<impl Iterator<Item = (usize, &'a syn::Field)>>,
+) -> TokenStream {
     let ident = field_ident(index, field);
 
-    if attributes_include(&field.attrs, "flatten") {
+    if is_opt {
+        let condition = remaining_opt_fields_some_condition(remaining);
+        quote! { self.#ident.as_ref().map(|val| alloy_rlp::RlpEncodable::rlp_len(val)).unwrap_or((#condition) as usize) }
+    } else if attributes_include(&field.attrs, "flatten") {
         quote! { alloy_rlp::RlpEncodable::rlp_len_raw(&self.#ident) }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_len(&self.#ident) }
@@ -318,10 +336,24 @@ fn encodable_field<'a>(
     }
 }
 
-fn encodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
+fn encodable_field_raw<'a>(
+    index: usize,
+    field: &syn::Field,
+    is_opt: bool,
+    remaining: Peekable<impl Iterator<Item = (usize, &'a syn::Field)>>,
+) -> TokenStream {
     let ident = field_ident(index, field);
 
-    if attributes_include(&field.attrs, "flatten") {
+    if is_opt {
+        let condition = remaining_opt_fields_some_condition(remaining);
+        quote! {
+            if let Some(val) = self.#ident.as_ref() {
+                alloy_rlp::RlpEncodable::rlp_encode(val, out)
+            } else if #condition {
+                out.put_u8(#EMPTY_STRING_CODE);
+            }
+        }
+    } else if attributes_include(&field.attrs, "flatten") {
         quote! { alloy_rlp::RlpEncodable::rlp_encode_raw(&self.#ident, out); }
     } else {
         quote! { alloy_rlp::RlpEncodable::rlp_encode(&self.#ident, out); }
@@ -331,11 +363,13 @@ fn encodable_field_raw(index: usize, field: &syn::Field) -> TokenStream {
 fn remaining_opt_fields_some_condition<'a>(
     remaining: impl Iterator<Item = (usize, &'a syn::Field)>,
 ) -> TokenStream {
-    let conditions = remaining.map(|(index, field)| {
-        let ident = field_ident(index, field);
-        quote! { self.#ident.is_some() }
-    });
-    quote! { #(#conditions)||* }
+    let conditions = remaining
+        .filter(|(_, field)| is_optional(field) && !attributes_include(&field.attrs, "default"))
+        .map(|(index, field)| {
+            let ident = field_ident(index, field);
+            quote! { self.#ident.is_some() }
+        });
+    quote! { false #(|| #conditions)* }
 }
 
 pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStream> {
@@ -433,7 +467,7 @@ pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStrea
                 }
 
                 #[inline]
-                fn rlp_encode(&self, out: &mut alloy_rlp::Encoder<'_>) {
+                fn rlp_encode<__AlloyRlpBuf: alloy_rlp::BufMut>(&self, out: &mut alloy_rlp::Encoder<__AlloyRlpBuf>) {
                     let payload_length = match self {
                         #(#length_arms)*
                     };
@@ -445,6 +479,11 @@ pub(crate) fn impl_encodable_tagged(ast: &syn::DeriveInput) -> Result<TokenStrea
                     match self {
                         #(#encode_arms)*
                     }
+                }
+
+                #[inline]
+                fn rlp_len_raw(&self) -> usize {
+                    self.rlp_len()
                 }
             }
         };

--- a/crates/rlp-derive/src/utils.rs
+++ b/crates/rlp-derive/src/utils.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse_quote, Attribute, DataStruct, Error, Field, GenericParam, Generics, Meta, Result, Type,
-    TypePath,
+    parse_quote, Attribute, DataEnum, DataStruct, Error, Field, GenericParam, Generics, Meta,
+    Result, Type, TypePath,
 };
 
 pub(crate) const EMPTY_STRING_CODE: u8 = 0x80;
@@ -17,6 +17,17 @@ pub(crate) fn parse_struct<'a>(
         Err(Error::new_spanned(
             ast,
             format!("#[derive({derive_attr})] is only defined for structs."),
+        ))
+    }
+}
+
+pub(crate) fn parse_enum<'a>(ast: &'a syn::DeriveInput, derive_attr: &str) -> Result<&'a DataEnum> {
+    if let syn::Data::Enum(e) = &ast.data {
+        Ok(e)
+    } else {
+        Err(Error::new_spanned(
+            ast,
+            format!("#[derive({derive_attr})] with `#[rlp(tagged)]` is only defined for enums."),
         ))
     }
 }
@@ -39,6 +50,23 @@ pub(crate) fn attributes_include(attrs: &[Attribute], attr_name: &str) -> bool {
         }
     }
     false
+}
+
+pub(crate) fn get_tag_value(attrs: &[Attribute]) -> Result<Option<syn::Expr>> {
+    let mut value = None;
+    for attr in attrs {
+        if attr.path().is_ident("rlp") {
+            if let Meta::List(meta) = &attr.meta {
+                meta.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("tag") {
+                        value = Some(meta.value()?.parse()?);
+                    }
+                    Ok(())
+                })?;
+            }
+        }
+    }
+    Ok(value)
 }
 
 pub(crate) fn is_optional(field: &Field) -> bool {

--- a/crates/rlp-derive/src/utils.rs
+++ b/crates/rlp-derive/src/utils.rs
@@ -70,14 +70,26 @@ pub(crate) fn get_tag_value(attrs: &[Attribute]) -> Result<Option<syn::Expr>> {
 }
 
 pub(crate) fn is_optional(field: &Field) -> bool {
+    option_inner_type(field).is_some()
+}
+
+pub(crate) fn option_inner_type(field: &Field) -> Option<&syn::Type> {
     if let Type::Path(TypePath { qself, path }) = &field.ty {
-        qself.is_none()
+        if qself.is_none()
             && path.leading_colon.is_none()
             && path.segments.len() == 1
             && path.segments.first().unwrap().ident == "Option"
-    } else {
-        false
+        {
+            if let syn::PathArguments::AngleBracketed(args) =
+                &path.segments.first().unwrap().arguments
+            {
+                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                    return Some(inner);
+                }
+            }
+        }
     }
+    None
 }
 
 pub(crate) fn field_ident(index: usize, field: &syn::Field) -> TokenStream {

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -28,6 +28,7 @@ arrayvec = { workspace = true, optional = true }
 [dev-dependencies]
 hex.workspace = true
 hex-literal.workspace = true
+trybuild = "1"
 
 [features]
 default = ["std"]

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -28,7 +28,9 @@ arrayvec = { workspace = true, optional = true }
 [dev-dependencies]
 hex.workspace = true
 hex-literal.workspace = true
-trybuild = "1"
+# Keep exact for MSRV CI: newer trybuild releases pull TOML parser stacks whose
+# manifests or rust-version exceed this crate's rust-version.
+trybuild = "=1.0.80"
 
 [features]
 default = ["std"]

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -28,8 +28,6 @@ arrayvec = { workspace = true, optional = true }
 [dev-dependencies]
 hex.workspace = true
 hex-literal.workspace = true
-# Keep exact for MSRV CI: newer trybuild releases pull TOML parser stacks whose
-# manifests or rust-version exceed this crate's rust-version.
 trybuild = "=1.0.80"
 
 [features]

--- a/crates/rlp/README.md
+++ b/crates/rlp/README.md
@@ -36,3 +36,35 @@ let decoded = MyStruct::rlp_decode(&mut buffer.as_slice()).unwrap();
 assert_eq!(my_struct, decoded);
 # }
 ```
+
+The derive macros reject ambiguous enum and flatten shapes:
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+enum NotTagged {
+    A,
+}
+```
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+struct BadFlatten {
+    #[rlp(flatten)]
+    field: Option<u64>,
+}
+```
+
+```compile_fail
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+#[rlp(transparent)]
+struct BadTransparent {
+    a: u64,
+    b: u64,
+}
+```

--- a/crates/rlp/README.md
+++ b/crates/rlp/README.md
@@ -17,7 +17,7 @@ Trait methods can then be accessed via the `RlpEncodable` and `RlpDecodable` tra
 
 ```rust
 # #[cfg(feature = "derive")] {
-use alloy_rlp::{RlpEncodable, RlpDecodable, Encoder};
+use alloy_rlp::{decode_exact, RlpEncodable, RlpDecodable, Encoder};
 
 #[derive(Debug, RlpEncodable, RlpDecodable, PartialEq)]
 pub struct MyStruct {
@@ -32,7 +32,7 @@ let my_struct = MyStruct {
 
 let mut buffer = Vec::<u8>::new();
 my_struct.rlp_encode(&mut Encoder::new(&mut buffer));
-let decoded = MyStruct::rlp_decode(&mut buffer.as_slice()).unwrap();
+let decoded = decode_exact::<MyStruct>(&buffer).unwrap();
 assert_eq!(my_struct, decoded);
 # }
 ```

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -471,6 +471,10 @@ where
 }
 
 /// Decodes a raw optional field without consuming items reserved for enclosing fields.
+///
+/// When another raw optional field follows, `0x80` is interpreted as the `None` gap sentinel.
+/// That byte is also the valid RLP encoding of values such as `0`, `false`, and empty strings, so
+/// those values are only unambiguous when no later optional raw field is present.
 #[doc(hidden)]
 #[inline]
 pub fn decode_optional_raw<'de, T: RlpDecodable<'de>>(

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorKind, Header, Result};
+use crate::{Error, ErrorKind, Header, Result};
 use bytes::{Bytes, BytesMut};
 use core::marker::{PhantomData, PhantomPinned};
 
@@ -7,6 +7,154 @@ pub trait RlpDecodable: Sized {
     /// Decodes the blob into the appropriate type. `buf` must be advanced past
     /// the decoded object.
     fn rlp_decode(buf: &mut &[u8]) -> Result<Self>;
+
+    /// Decodes this value from a buffer that omits the value's outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by decoding the value normally.
+    /// Structured implementations may override this to read their fields sequentially.
+    #[inline]
+    fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
+        Self::rlp_decode(buf)
+    }
+}
+
+/// An active RLP decoder that tracks byte position while advancing through an input buffer.
+#[derive(Clone, Debug)]
+pub struct Decoder<'de> {
+    buf: &'de [u8],
+    bytepos: usize,
+}
+
+impl<'de> Decoder<'de> {
+    /// Instantiate an RLP decoder with an input slice.
+    #[inline]
+    pub const fn new(buf: &'de [u8]) -> Self {
+        Self { buf, bytepos: 0 }
+    }
+
+    /// Instantiate an RLP decoder with an input slice and starting byte position.
+    #[inline]
+    pub const fn with_bytepos(buf: &'de [u8], bytepos: usize) -> Self {
+        Self { buf, bytepos }
+    }
+
+    /// Returns the remaining undecoded input.
+    #[inline]
+    pub const fn as_slice(&self) -> &'de [u8] {
+        self.buf
+    }
+
+    /// Returns true if the decoder has no remaining input.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
+    /// Returns the current byte position.
+    #[inline]
+    pub const fn bytepos(&self) -> usize {
+        self.bytepos
+    }
+
+    /// Creates an error at the current byte position.
+    #[inline]
+    pub const fn error(&self, kind: ErrorKind) -> Error {
+        Error::with_bytepos(kind, self.bytepos)
+    }
+
+    /// Creates an error at the given byte position.
+    #[inline]
+    pub const fn error_at(&self, kind: ErrorKind, bytepos: usize) -> Error {
+        Error::with_bytepos(kind, bytepos)
+    }
+
+    /// Decodes the next RLP header, advancing past the header but not the payload.
+    #[inline]
+    pub fn decode_header(&mut self) -> Result<Header> {
+        let before = self.buf.len();
+        match Header::decode(&mut self.buf) {
+            Ok(header) => {
+                self.advance_bytepos(before);
+                Ok(header)
+            }
+            Err(err) => {
+                let err = self.map_error(before, err);
+                self.advance_bytepos(before);
+                Err(err)
+            }
+        }
+    }
+
+    /// Decodes the next payload from the buffer, advancing past the full item.
+    #[inline]
+    pub fn decode_bytes(&mut self, is_list: bool) -> Result<&'de [u8]> {
+        let item_start = self.bytepos;
+        let Header { list, payload_length } = self.decode_header()?;
+
+        if list != is_list {
+            return Err(Error::with_bytepos(
+                if is_list { ErrorKind::UnexpectedString } else { ErrorKind::UnexpectedList },
+                item_start,
+            ));
+        }
+
+        if self.buf.len() < payload_length {
+            return Err(self.error(ErrorKind::InputTooShort));
+        }
+
+        let (payload, rest) = self.buf.split_at(payload_length);
+        self.buf = rest;
+        self.bytepos = self.bytepos.saturating_add(payload_length);
+        Ok(payload)
+    }
+
+    /// Decodes a string slice from the buffer, advancing past the full item.
+    #[inline]
+    pub fn decode_str(&mut self) -> Result<&'de str> {
+        let item_start = self.bytepos;
+        let bytes = self.decode_bytes(false)?;
+        core::str::from_utf8(bytes)
+            .map_err(|_| Error::with_bytepos(ErrorKind::Custom("invalid string"), item_start))
+    }
+
+    /// Decodes the next item using [`RlpDecodable::rlp_decode`].
+    #[inline]
+    pub fn decode_next<T: RlpDecodable>(&mut self) -> Result<T> {
+        self.decode_with(T::rlp_decode)
+    }
+
+    /// Decodes the next item using [`RlpDecodable::rlp_decode_raw`].
+    #[inline]
+    pub fn decode_next_raw<T: RlpDecodable>(&mut self) -> Result<T> {
+        self.decode_with(T::rlp_decode_raw)
+    }
+
+    #[inline]
+    fn decode_with<T>(&mut self, f: impl FnOnce(&mut &'de [u8]) -> Result<T>) -> Result<T> {
+        let before = self.buf.len();
+        match f(&mut self.buf) {
+            Ok(value) => {
+                self.advance_bytepos(before);
+                Ok(value)
+            }
+            Err(err) => {
+                let err = self.map_error(before, err);
+                self.advance_bytepos(before);
+                Err(err)
+            }
+        }
+    }
+
+    #[inline]
+    fn advance_bytepos(&mut self, before: usize) {
+        self.bytepos = self.bytepos.saturating_add(before.saturating_sub(self.buf.len()));
+    }
+
+    #[inline]
+    const fn map_error(&self, before: usize, err: Error) -> Error {
+        let relative = before.saturating_sub(self.buf.len()).saturating_add(err.bytepos());
+        Error::with_bytepos(err.kind(), self.bytepos.saturating_add(relative))
+    }
 }
 
 /// An active RLP decoder, with a specific slice of a payload.
@@ -110,6 +258,51 @@ impl<T: RlpDecodable> RlpDecodable for alloc::vec::Vec<T> {
         }
         Ok(vec)
     }
+}
+
+macro_rules! tuple_impls {
+    ($(($($ty:ident),+)),+ $(,)?) => {$(
+        impl<$($ty: RlpDecodable),+> RlpDecodable for ($($ty,)+) {
+            #[inline]
+            fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
+                let mut payload = Header::decode_bytes(buf, true)?;
+                let started_len = payload.len();
+
+                let this = Self::rlp_decode_raw(&mut payload)?;
+
+                let consumed = started_len - payload.len();
+                if consumed != started_len {
+                    return Err(ErrorKind::ListLengthMismatch {
+                        expected: started_len,
+                        got: consumed,
+                    }
+                    .into());
+                }
+
+                Ok(this)
+            }
+
+            #[inline]
+            fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
+                Ok(($(<$ty as RlpDecodable>::rlp_decode(buf)?,)+))
+            }
+        }
+    )+};
+}
+
+tuple_impls! {
+    (A),
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+    (A, B, C, D, E, F, G, H, I),
+    (A, B, C, D, E, F, G, H, I, J),
+    (A, B, C, D, E, F, G, H, I, J, K),
+    (A, B, C, D, E, F, G, H, I, J, K, L),
 }
 
 macro_rules! wrap_impl {
@@ -399,5 +592,49 @@ mod tests {
         check_decode_exact::<String>("test1234".into());
         check_decode_exact::<Vec<u64>>(vec![]);
         check_decode_exact::<Vec<u64>>(vec![0; 4]);
+    }
+
+    #[test]
+    fn decoder_advances_bytepos() {
+        let mut input = Vec::new();
+        1u8.rlp_encode(&mut crate::Encoder::new(&mut input));
+        "cat".rlp_encode(&mut crate::Encoder::new(&mut input));
+
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        assert_eq!(decoder.bytepos(), 1);
+        assert_eq!(decoder.decode_str(), Ok("cat"));
+        assert_eq!(decoder.bytepos(), input.len());
+        assert!(decoder.is_empty());
+    }
+
+    #[test]
+    fn decoder_reports_error_bytepos() {
+        let input = [0x01, 0xC0];
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        let err = decoder.decode_bytes(false).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedList);
+        assert_eq!(err.bytepos(), 1);
+
+        let input = [0x01, 0x82];
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(1));
+        let err = decoder.decode_next::<u16>().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InputTooShort);
+        assert_eq!(err.bytepos(), 2);
+    }
+
+    #[test]
+    fn decoder_decode_next_raw() {
+        let mut input = Vec::new();
+        (1u8, 2u8).rlp_encode_raw(&mut crate::Encoder::new(&mut input));
+        3u8.rlp_encode(&mut crate::Encoder::new(&mut input));
+
+        let mut decoder = Decoder::new(&input);
+        assert_eq!(decoder.decode_next_raw::<(u8, u8)>(), Ok((1, 2)));
+        assert_eq!(decoder.bytepos(), 2);
+        assert_eq!(decoder.decode_next::<u8>(), Ok(3));
+        assert!(decoder.is_empty());
     }
 }

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -3,18 +3,18 @@ use bytes::{Bytes, BytesMut};
 use core::marker::{PhantomData, PhantomPinned};
 
 /// A type that can be decoded from an RLP blob.
-pub trait RlpDecodable: Sized {
-    /// Decodes the blob into the appropriate type. `buf` must be advanced past
+pub trait RlpDecodable<'de>: Sized {
+    /// Minimum number of raw RLP items this type needs to decode successfully.
+    const MIN_RAW_ITEMS: usize = 1;
+
+    /// Decodes the blob into the appropriate type. `decoder` must be advanced past
     /// the decoded object.
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self>;
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self>;
 
     /// Decodes this value from a buffer that omits the value's outer RLP list header.
-    ///
-    /// The default implementation preserves the historical behavior by decoding the value normally.
-    /// Structured implementations may override this to read their fields sequentially.
     #[inline]
-    fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
-        Self::rlp_decode(buf)
+    fn rlp_decode_raw(decoder: &mut Decoder<'de>) -> Result<Self> {
+        Self::rlp_decode(decoder)
     }
 }
 
@@ -23,19 +23,20 @@ pub trait RlpDecodable: Sized {
 pub struct Decoder<'de> {
     buf: &'de [u8],
     bytepos: usize,
+    raw_tail_items: usize,
 }
 
 impl<'de> Decoder<'de> {
     /// Instantiate an RLP decoder with an input slice.
     #[inline]
     pub const fn new(buf: &'de [u8]) -> Self {
-        Self { buf, bytepos: 0 }
+        Self { buf, bytepos: 0, raw_tail_items: 0 }
     }
 
     /// Instantiate an RLP decoder with an input slice and starting byte position.
     #[inline]
     pub const fn with_bytepos(buf: &'de [u8], bytepos: usize) -> Self {
-        Self { buf, bytepos }
+        Self { buf, bytepos, raw_tail_items: 0 }
     }
 
     /// Returns the remaining undecoded input.
@@ -50,10 +51,42 @@ impl<'de> Decoder<'de> {
         self.buf.is_empty()
     }
 
+    /// Returns the number of remaining undecoded bytes.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.buf.len()
+    }
+
     /// Returns the current byte position.
     #[inline]
     pub const fn bytepos(&self) -> usize {
         self.bytepos
+    }
+
+    /// Returns the raw item count reserved for enclosing flattened fields.
+    #[inline]
+    pub const fn raw_tail_items(&self) -> usize {
+        self.raw_tail_items
+    }
+
+    /// Temporarily sets the raw item count reserved for enclosing flattened fields.
+    #[inline]
+    pub fn with_raw_tail_items<R>(
+        &mut self,
+        raw_tail_items: usize,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let previous = self.raw_tail_items;
+        self.raw_tail_items = raw_tail_items;
+        let result = f(self);
+        self.raw_tail_items = previous;
+        result
+    }
+
+    /// Returns the next undecoded byte without advancing.
+    #[inline]
+    pub fn peek(&self) -> Option<u8> {
+        self.buf.first().copied()
     }
 
     /// Creates an error at the current byte position.
@@ -72,22 +105,38 @@ impl<'de> Decoder<'de> {
     #[inline]
     pub fn decode_header(&mut self) -> Result<Header> {
         let before = self.buf.len();
-        match Header::decode(&mut self.buf) {
+        match Header::decode_at(&mut self.buf, self.bytepos) {
             Ok(header) => {
                 self.advance_bytepos(before);
                 Ok(header)
             }
             Err(err) => {
-                let err = self.map_error(before, err);
                 self.advance_bytepos(before);
                 Err(err)
             }
         }
     }
 
+    /// Advances by `cnt` bytes and returns the advanced-over slice.
+    #[inline]
+    pub fn advance(&mut self, cnt: usize) -> Result<&'de [u8]> {
+        if self.buf.len() < cnt {
+            return Err(self.error(ErrorKind::InputTooShort));
+        }
+        let (bytes, rest) = self.buf.split_at(cnt);
+        self.buf = rest;
+        self.bytepos = self.bytepos.saturating_add(cnt);
+        Ok(bytes)
+    }
+
     /// Decodes the next payload from the buffer, advancing past the full item.
     #[inline]
     pub fn decode_bytes(&mut self, is_list: bool) -> Result<&'de [u8]> {
+        self.decode_bytes_with_position(is_list).map(|(bytes, _)| bytes)
+    }
+
+    #[inline]
+    fn decode_bytes_with_position(&mut self, is_list: bool) -> Result<(&'de [u8], usize)> {
         let item_start = self.bytepos;
         let Header { list, payload_length } = self.decode_header()?;
 
@@ -98,127 +147,139 @@ impl<'de> Decoder<'de> {
             ));
         }
 
-        if self.buf.len() < payload_length {
-            return Err(self.error(ErrorKind::InputTooShort));
-        }
+        let payload_start = self.bytepos;
+        self.advance(payload_length).map(|bytes| (bytes, payload_start))
+    }
 
-        let (payload, rest) = self.buf.split_at(payload_length);
-        self.buf = rest;
-        self.bytepos = self.bytepos.saturating_add(payload_length);
-        Ok(payload)
+    /// Decodes the next payload as a nested decoder.
+    #[inline]
+    pub fn decode_payload(&mut self, is_list: bool) -> Result<Self> {
+        let (payload, payload_start) = self.decode_bytes_with_position(is_list)?;
+        Ok(Self::with_bytepos(payload, payload_start))
     }
 
     /// Decodes a string slice from the buffer, advancing past the full item.
     #[inline]
     pub fn decode_str(&mut self) -> Result<&'de str> {
-        let item_start = self.bytepos;
-        let bytes = self.decode_bytes(false)?;
+        let (bytes, payload_start) = self.decode_bytes_with_position(false)?;
         core::str::from_utf8(bytes)
-            .map_err(|_| Error::with_bytepos(ErrorKind::Custom("invalid string"), item_start))
+            .map_err(|_| Error::with_bytepos(ErrorKind::Custom("invalid string"), payload_start))
     }
 
     /// Decodes the next item using [`RlpDecodable::rlp_decode`].
     #[inline]
-    pub fn decode_next<T: RlpDecodable>(&mut self) -> Result<T> {
-        self.decode_with(T::rlp_decode)
+    pub fn decode_next<T: RlpDecodable<'de>>(&mut self) -> Result<T> {
+        T::rlp_decode(self)
     }
 
     /// Decodes the next item using [`RlpDecodable::rlp_decode_raw`].
     #[inline]
-    pub fn decode_next_raw<T: RlpDecodable>(&mut self) -> Result<T> {
-        self.decode_with(T::rlp_decode_raw)
+    pub fn decode_next_raw<T: RlpDecodable<'de>>(&mut self) -> Result<T> {
+        T::rlp_decode_raw(self)
     }
 
+    /// Counts the remaining RLP items without advancing this decoder.
     #[inline]
-    fn decode_with<T>(&mut self, f: impl FnOnce(&mut &'de [u8]) -> Result<T>) -> Result<T> {
-        let before = self.buf.len();
-        match f(&mut self.buf) {
-            Ok(value) => {
-                self.advance_bytepos(before);
-                Ok(value)
-            }
-            Err(err) => {
-                let err = self.map_error(before, err);
-                self.advance_bytepos(before);
-                Err(err)
-            }
+    pub fn remaining_rlp_items(&self) -> Result<usize> {
+        let mut decoder = Self::with_bytepos(self.buf, self.bytepos);
+        let mut count = 0usize;
+        while !decoder.is_empty() {
+            decoder.skip_next()?;
+            count = count.saturating_add(1);
         }
+        Ok(count)
+    }
+
+    /// Skips the next RLP item.
+    #[inline]
+    pub fn skip_next(&mut self) -> Result<()> {
+        let Header { payload_length, .. } = self.decode_header()?;
+        self.advance(payload_length)?;
+        Ok(())
     }
 
     #[inline]
     fn advance_bytepos(&mut self, before: usize) {
         self.bytepos = self.bytepos.saturating_add(before.saturating_sub(self.buf.len()));
     }
-
-    #[inline]
-    const fn map_error(&self, before: usize, err: Error) -> Error {
-        let relative = before.saturating_sub(self.buf.len()).saturating_add(err.bytepos());
-        Error::with_bytepos(err.kind(), self.bytepos.saturating_add(relative))
-    }
 }
 
 /// An active RLP decoder, with a specific slice of a payload.
 #[derive(Debug)]
 pub struct Rlp<'a> {
-    payload_view: &'a [u8],
+    decoder: Decoder<'a>,
 }
 
 impl<'a> Rlp<'a> {
     /// Instantiate an RLP decoder with a payload slice.
-    pub fn new(mut payload: &'a [u8]) -> Result<Self> {
-        let payload_view = Header::decode_bytes(&mut payload, true)?;
-        Ok(Self { payload_view })
+    pub fn new(payload: &'a [u8]) -> Result<Self> {
+        let mut decoder = Decoder::new(payload);
+        let decoder = decoder.decode_payload(true)?;
+        Ok(Self { decoder })
     }
 
     /// Decode the next item from the buffer.
     #[inline]
-    pub fn get_next<T: RlpDecodable>(&mut self) -> Result<Option<T>> {
-        if self.payload_view.is_empty() {
+    pub fn get_next<T: RlpDecodable<'a>>(&mut self) -> Result<Option<T>> {
+        if self.decoder.is_empty() {
             Ok(None)
         } else {
-            T::rlp_decode(&mut self.payload_view).map(Some)
+            T::rlp_decode(&mut self.decoder).map(Some)
         }
     }
 }
 
-impl<T: ?Sized> RlpDecodable for PhantomData<T> {
-    fn rlp_decode(_buf: &mut &[u8]) -> Result<Self> {
+impl<'de, T: ?Sized> RlpDecodable<'de> for PhantomData<T> {
+    const MIN_RAW_ITEMS: usize = 0;
+
+    fn rlp_decode(_decoder: &mut Decoder<'de>) -> Result<Self> {
         Ok(Self)
     }
 }
 
-impl RlpDecodable for PhantomPinned {
-    fn rlp_decode(_buf: &mut &[u8]) -> Result<Self> {
+impl<'de> RlpDecodable<'de> for PhantomPinned {
+    const MIN_RAW_ITEMS: usize = 0;
+
+    fn rlp_decode(_decoder: &mut Decoder<'de>) -> Result<Self> {
         Ok(Self)
     }
 }
 
-impl RlpDecodable for bool {
+impl<'de> RlpDecodable<'de> for bool {
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        Ok(match u8::rlp_decode(buf)? {
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        let bytepos = decoder.bytepos();
+        Ok(match u8::rlp_decode(decoder)? {
             0 => false,
             1 => true,
-            _ => return Err(ErrorKind::Custom("invalid bool value, must be 0 or 1").into()),
+            _ => {
+                return Err(Error::with_bytepos(
+                    ErrorKind::Custom("invalid bool value, must be 0 or 1"),
+                    bytepos,
+                ))
+            }
         })
     }
 }
 
-impl<const N: usize> RlpDecodable for [u8; N] {
+impl<'de, const N: usize> RlpDecodable<'de> for [u8; N] {
     #[inline]
-    fn rlp_decode(from: &mut &[u8]) -> Result<Self> {
-        let bytes = Header::decode_bytes(from, false)?;
-        Self::try_from(bytes).map_err(|_| ErrorKind::UnexpectedLength.into())
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        let (bytes, payload_start) = decoder.decode_bytes_with_position(false)?;
+        Self::try_from(bytes)
+            .map_err(|_| Error::with_bytepos(ErrorKind::UnexpectedLength, payload_start))
     }
 }
 
 macro_rules! decode_integer {
     ($($t:ty),+ $(,)?) => {$(
-        impl RlpDecodable for $t {
+        impl<'de> RlpDecodable<'de> for $t {
             #[inline]
-            fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-                let bytes = Header::decode_bytes(buf, false)?;
-                static_left_pad(bytes).map(<$t>::from_be_bytes)
+            fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+                let (bytes, payload_start) = decoder.decode_bytes_with_position(false)?;
+                static_left_pad(bytes)
+                    .map(<$t>::from_be_bytes)
+                    .map_err(|err| Error::with_bytepos(err.kind(), payload_start.saturating_add(err.bytepos())))
             }
         }
     )+};
@@ -226,35 +287,34 @@ macro_rules! decode_integer {
 
 decode_integer!(u8, u16, u32, u64, usize, u128);
 
-impl RlpDecodable for Bytes {
+impl<'de> RlpDecodable<'de> for Bytes {
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        Header::decode_bytes(buf, false).map(|x| Self::from(x.to_vec()))
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        decoder.decode_bytes(false).map(|x| Self::from(x.to_vec()))
     }
 }
 
-impl RlpDecodable for BytesMut {
+impl<'de> RlpDecodable<'de> for BytesMut {
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        Header::decode_bytes(buf, false).map(Self::from)
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        decoder.decode_bytes(false).map(Self::from)
     }
 }
 
-impl RlpDecodable for alloc::string::String {
+impl<'de> RlpDecodable<'de> for alloc::string::String {
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        Header::decode_str(buf).map(Into::into)
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        decoder.decode_str().map(Into::into)
     }
 }
 
-impl<T: RlpDecodable> RlpDecodable for alloc::vec::Vec<T> {
+impl<'de, T: RlpDecodable<'de>> RlpDecodable<'de> for alloc::vec::Vec<T> {
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        let mut bytes = Header::decode_bytes(buf, true)?;
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        let mut payload = decoder.decode_payload(true)?;
         let mut vec = Self::new();
-        let payload_view = &mut bytes;
-        while !payload_view.is_empty() {
-            vec.push(T::rlp_decode(payload_view)?);
+        while !payload.is_empty() {
+            vec.push(T::rlp_decode(&mut payload)?);
         }
         Ok(vec)
     }
@@ -262,29 +322,30 @@ impl<T: RlpDecodable> RlpDecodable for alloc::vec::Vec<T> {
 
 macro_rules! tuple_impls {
     ($(($($ty:ident),+)),+ $(,)?) => {$(
-        impl<$($ty: RlpDecodable),+> RlpDecodable for ($($ty,)+) {
+        impl<'de, $($ty: RlpDecodable<'de>),+> RlpDecodable<'de> for ($($ty,)+) {
+            const MIN_RAW_ITEMS: usize = 0usize $(+ <$ty as RlpDecodable<'de>>::MIN_RAW_ITEMS)+;
+
             #[inline]
-            fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-                let mut payload = Header::decode_bytes(buf, true)?;
+            fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+                let mut payload = decoder.decode_payload(true)?;
                 let started_len = payload.len();
 
                 let this = Self::rlp_decode_raw(&mut payload)?;
 
-                let consumed = started_len - payload.len();
+                let consumed = started_len.saturating_sub(payload.len());
                 if consumed != started_len {
-                    return Err(ErrorKind::ListLengthMismatch {
-                        expected: started_len,
-                        got: consumed,
-                    }
-                    .into());
+                    return Err(payload.error(ErrorKind::ListLengthMismatch {
+                            expected: started_len,
+                            got: consumed,
+                        }));
                 }
 
                 Ok(this)
             }
 
             #[inline]
-            fn rlp_decode_raw(buf: &mut &[u8]) -> Result<Self> {
-                Ok(($(<$ty as RlpDecodable>::rlp_decode(buf)?,)+))
+            fn rlp_decode_raw(decoder: &mut Decoder<'de>) -> Result<Self> {
+                Ok(($(<$ty as RlpDecodable<'de>>::rlp_decode(decoder)?,)+))
             }
         }
     )+};
@@ -308,10 +369,12 @@ tuple_impls! {
 macro_rules! wrap_impl {
     ($($(#[$attr:meta])* [$($gen:tt)*] <$t:ty>::$new:ident($t2:ty)),+ $(,)?) => {$(
         $(#[$attr])*
-        impl<$($gen)*> RlpDecodable for $t {
+        impl<'de, $($gen)*> RlpDecodable<'de> for $t {
+            const MIN_RAW_ITEMS: usize = <$t2 as RlpDecodable<'de>>::MIN_RAW_ITEMS;
+
             #[inline]
-            fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-                <$t2 as RlpDecodable>::rlp_decode(buf).map(<$t>::$new)
+            fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+                <$t2 as RlpDecodable<'de>>::rlp_decode(decoder).map(<$t>::$new)
             }
         }
     )+};
@@ -320,19 +383,21 @@ macro_rules! wrap_impl {
 wrap_impl! {
     #[cfg(feature = "arrayvec")]
     [const N: usize] <arrayvec::ArrayVec<u8, N>>::from([u8; N]),
-    [T: RlpDecodable] <alloc::boxed::Box<T>>::new(T),
-    [T: RlpDecodable] <alloc::rc::Rc<T>>::new(T),
+    [T: RlpDecodable<'de>] <alloc::boxed::Box<T>>::new(T),
+    [T: RlpDecodable<'de>] <alloc::rc::Rc<T>>::new(T),
     #[cfg(target_has_atomic = "ptr")]
-    [T: RlpDecodable] <alloc::sync::Arc<T>>::new(T),
+    [T: RlpDecodable<'de>] <alloc::sync::Arc<T>>::new(T),
 }
 
-impl<T: ?Sized + alloc::borrow::ToOwned> RlpDecodable for alloc::borrow::Cow<'_, T>
+impl<'de, T: ?Sized + alloc::borrow::ToOwned> RlpDecodable<'de> for alloc::borrow::Cow<'_, T>
 where
-    T::Owned: RlpDecodable,
+    T::Owned: RlpDecodable<'de>,
 {
+    const MIN_RAW_ITEMS: usize = <T::Owned as RlpDecodable<'de>>::MIN_RAW_ITEMS;
+
     #[inline]
-    fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-        T::Owned::rlp_decode(buf).map(Self::Owned)
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+        T::Owned::rlp_decode(decoder).map(Self::Owned)
     }
 }
 
@@ -344,32 +409,36 @@ mod std_impl {
     #[cfg(feature = "std")]
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-    impl RlpDecodable for IpAddr {
-        fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-            let bytes = Header::decode_bytes(buf, false)?;
+    impl<'de> RlpDecodable<'de> for IpAddr {
+        fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+            let (bytes, payload_start) = decoder.decode_bytes_with_position(false)?;
             match bytes.len() {
                 4 => Ok(Self::V4(Ipv4Addr::from(slice_to_array::<4>(bytes).expect("infallible")))),
                 16 => {
                     Ok(Self::V6(Ipv6Addr::from(slice_to_array::<16>(bytes).expect("infallible"))))
                 }
-                _ => Err(ErrorKind::UnexpectedLength.into()),
+                _ => Err(Error::with_bytepos(ErrorKind::UnexpectedLength, payload_start)),
             }
         }
     }
 
-    impl RlpDecodable for Ipv4Addr {
+    impl<'de> RlpDecodable<'de> for Ipv4Addr {
         #[inline]
-        fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-            let bytes = Header::decode_bytes(buf, false)?;
-            slice_to_array::<4>(bytes).map(Self::from)
+        fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+            let (bytes, payload_start) = decoder.decode_bytes_with_position(false)?;
+            slice_to_array::<4>(bytes)
+                .map(Self::from)
+                .map_err(|err| Error::with_bytepos(err.kind(), payload_start))
         }
     }
 
-    impl RlpDecodable for Ipv6Addr {
+    impl<'de> RlpDecodable<'de> for Ipv6Addr {
         #[inline]
-        fn rlp_decode(buf: &mut &[u8]) -> Result<Self> {
-            let bytes = Header::decode_bytes(buf, false)?;
-            slice_to_array::<16>(bytes).map(Self::from)
+        fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self> {
+            let (bytes, payload_start) = decoder.decode_bytes_with_position(false)?;
+            slice_to_array::<16>(bytes)
+                .map(Self::from)
+                .map_err(|err| Error::with_bytepos(err.kind(), payload_start))
         }
     }
 
@@ -385,17 +454,43 @@ mod std_impl {
 ///
 /// Returns an error if the encoding is invalid or if data remains after decoding the RLP item.
 #[inline]
-pub fn decode_exact<T: RlpDecodable>(bytes: impl AsRef<[u8]>) -> Result<T> {
-    let mut buf = bytes.as_ref();
-    let out = T::rlp_decode(&mut buf)?;
+pub fn decode_exact<T>(bytes: impl AsRef<[u8]>) -> Result<T>
+where
+    T: for<'de> RlpDecodable<'de>,
+{
+    let mut decoder = Decoder::new(bytes.as_ref());
+    let out = T::rlp_decode(&mut decoder)?;
 
     // check if there are any remaining bytes after decoding
-    if !buf.is_empty() {
+    if !decoder.is_empty() {
         // TODO: introduce a new variant TrailingBytes to better distinguish this error
-        return Err(ErrorKind::UnexpectedLength.into());
+        return Err(decoder.error(ErrorKind::UnexpectedLength));
     }
 
     Ok(out)
+}
+
+/// Decodes a raw optional field without consuming items reserved for enclosing fields.
+#[doc(hidden)]
+#[inline]
+pub fn decode_optional_raw<'de, T: RlpDecodable<'de>>(
+    decoder: &mut Decoder<'de>,
+    min_tail_items: usize,
+) -> Result<Option<T>> {
+    let reserved_items = decoder.raw_tail_items().saturating_add(min_tail_items);
+    let remaining_items = decoder.remaining_rlp_items()?;
+    if remaining_items <= reserved_items {
+        return Ok(None);
+    }
+
+    if remaining_items > reserved_items.saturating_add(1)
+        && decoder.peek() == Some(crate::EMPTY_STRING_CODE)
+    {
+        decoder.advance(1)?;
+        Ok(None)
+    } else {
+        T::rlp_decode(decoder).map(Some)
+    }
 }
 
 /// Left-pads a slice to a statically known size array.
@@ -435,24 +530,28 @@ mod tests {
     #[allow(unused_imports)]
     use alloc::{string::String, vec::Vec};
 
-    /// Helper to create an `Error` from an `ErrorKind` with bytepos 0.
     fn err(kind: ErrorKind) -> Error {
         Error::new(kind)
     }
 
+    fn err_at(kind: ErrorKind, bytepos: usize) -> Error {
+        Error::with_bytepos(kind, bytepos)
+    }
+
     fn check_decode<'a, T, IT>(fixtures: IT)
     where
-        T: RlpEncodable + RlpDecodable + PartialEq + Debug,
+        T: RlpEncodable + for<'de> RlpDecodable<'de> + PartialEq + Debug,
         IT: IntoIterator<Item = (Result<T>, &'a [u8])>,
     {
-        for (expected, mut input) in fixtures {
+        for (expected, input) in fixtures {
             if let Ok(expected) = &expected {
                 assert_eq!(crate::encode(expected), input, "{expected:?}");
             }
 
             let orig = input;
+            let mut decoder = Decoder::new(input);
             assert_eq!(
-                T::rlp_decode(&mut input),
+                T::rlp_decode(&mut decoder),
                 expected,
                 "input: {}{}",
                 hex::encode(orig),
@@ -463,7 +562,7 @@ mod tests {
             );
 
             if expected.is_ok() {
-                assert_eq!(input, &[]);
+                assert!(decoder.is_empty());
             }
         }
     }
@@ -471,11 +570,11 @@ mod tests {
     #[test]
     fn rlp_bool() {
         let out = [0x80];
-        let val = bool::rlp_decode(&mut &out[..]);
+        let val = bool::rlp_decode(&mut Decoder::new(&out));
         assert_eq!(Ok(false), val);
 
         let out = [0x01];
-        let val = bool::rlp_decode(&mut &out[..]);
+        let val = bool::rlp_decode(&mut Decoder::new(&out));
         assert_eq!(Ok(true), val);
     }
 
@@ -495,8 +594,11 @@ mod tests {
     fn rlp_fixed_length() {
         check_decode([
             (Ok(hex!("6f62636465666768696a6b6c6d")), &hex!("8D6F62636465666768696A6B6C6D")[..]),
-            (Err(err(ErrorKind::UnexpectedLength)), &hex!("8C6F62636465666768696A6B6C")[..]),
-            (Err(err(ErrorKind::UnexpectedLength)), &hex!("8E6F62636465666768696A6B6C6D6E")[..]),
+            (Err(err_at(ErrorKind::UnexpectedLength, 1)), &hex!("8C6F62636465666768696A6B6C")[..]),
+            (
+                Err(err_at(ErrorKind::UnexpectedLength, 1)),
+                &hex!("8E6F62636465666768696A6B6C6D6E")[..],
+            ),
         ])
     }
 
@@ -507,15 +609,15 @@ mod tests {
             (Ok(0_u64), &hex!("80")[..]),
             (Ok(0x0505_u64), &hex!("820505")[..]),
             (Ok(0xCE05050505_u64), &hex!("85CE05050505")[..]),
-            (Err(err(ErrorKind::Overflow)), &hex!("8AFFFFFFFFFFFFFFFFFF7C")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("8BFFFFFFFFFFFFFFFFFF7C")[..]),
+            (Err(err_at(ErrorKind::Overflow, 1)), &hex!("8AFFFFFFFFFFFFFFFFFF7C")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("8BFFFFFFFFFFFFFFFFFF7C")[..]),
             (Err(err(ErrorKind::UnexpectedList)), &hex!("C0")[..]),
             (Err(err(ErrorKind::LeadingZero)), &hex!("00")[..]),
-            (Err(err(ErrorKind::NonCanonicalSingleByte)), &hex!("8105")[..]),
-            (Err(err(ErrorKind::LeadingZero)), &hex!("8200F4")[..]),
-            (Err(err(ErrorKind::NonCanonicalSize)), &hex!("B8020004")[..]),
+            (Err(err_at(ErrorKind::NonCanonicalSingleByte, 1)), &hex!("8105")[..]),
+            (Err(err_at(ErrorKind::LeadingZero, 1)), &hex!("8200F4")[..]),
+            (Err(err_at(ErrorKind::NonCanonicalSize, 2)), &hex!("B8020004")[..]),
             (
-                Err(err(ErrorKind::Overflow)),
+                Err(err_at(ErrorKind::Overflow, 1)),
                 &hex!("A101000000000000000000000000000000000000008B000000000000000000000000")[..],
             ),
         ])
@@ -549,42 +651,45 @@ mod tests {
     #[test]
     fn malformed_rlp() {
         check_decode::<Bytes, _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
         check_decode::<[u8; 5], _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
         #[cfg(feature = "std")]
         check_decode::<std::net::IpAddr, _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
         check_decode::<Vec<u8>, _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
         check_decode::<String, _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
         check_decode::<String, _>([
-            (Err(err(ErrorKind::InputTooShort)), &hex!("C1")[..]),
-            (Err(err(ErrorKind::InputTooShort)), &hex!("D7")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("C1")[..]),
+            (Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("D7")[..]),
         ]);
-        check_decode::<u8, _>([(Err(err(ErrorKind::InputTooShort)), &hex!("82")[..])]);
-        check_decode::<u64, _>([(Err(err(ErrorKind::InputTooShort)), &hex!("82")[..])]);
+        check_decode::<u8, _>([(Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("82")[..])]);
+        check_decode::<u64, _>([(Err(err_at(ErrorKind::InputTooShort, 1)), &hex!("82")[..])]);
     }
 
     #[test]
     fn rlp_full() {
-        fn check_decode_exact<T: RlpDecodable + RlpEncodable + PartialEq + Debug>(input: T) {
+        fn check_decode_exact<T: for<'de> RlpDecodable<'de> + RlpEncodable + PartialEq + Debug>(
+            input: T,
+        ) {
             let encoded = encode(&input);
+            let encoded_len = encoded.len();
             assert_eq!(decode_exact::<T>(&encoded), Ok(input));
             assert_eq!(
                 decode_exact::<T>([encoded, vec![0x00]].concat()),
-                Err(Error::new(ErrorKind::UnexpectedLength))
+                Err(Error::with_bytepos(ErrorKind::UnexpectedLength, encoded_len))
             );
         }
 

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -47,6 +47,15 @@ pub trait RlpEncodable {
     /// Encodes the type into the `out` buffer.
     fn rlp_encode(&self, out: &mut Encoder<'_>);
 
+    /// Encodes this value without its outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by encoding the value normally.
+    /// Structured implementations may override this to emit their fields sequentially.
+    #[inline]
+    fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+        self.rlp_encode(out);
+    }
+
     /// Returns the length of the encoding of this type in bytes.
     ///
     /// The default implementation computes this by encoding the type.
@@ -57,6 +66,15 @@ pub trait RlpEncodable {
         let mut out = Vec::new();
         self.rlp_encode(&mut Encoder::new(&mut out));
         out.len()
+    }
+
+    /// Returns the length of this value when encoded without its outer RLP list header.
+    ///
+    /// The default implementation preserves the historical behavior by returning the normal encoded
+    /// length. Structured implementations may override this to return only their payload length.
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -237,6 +255,49 @@ impl<T: RlpEncodable> RlpEncodable for Vec<T> {
     }
 }
 
+macro_rules! tuple_impls {
+    ($(($($ty:ident $idx:tt),+)),+ $(,)?) => {$(
+        impl<$($ty: RlpEncodable),+> RlpEncodable for ($($ty,)+) {
+            #[inline]
+            fn rlp_len(&self) -> usize {
+                let payload_length = self.rlp_len_raw();
+                payload_length + length_of_length(payload_length)
+            }
+
+            #[inline]
+            fn rlp_encode(&self, out: &mut Encoder<'_>) {
+                Header { list: true, payload_length: self.rlp_len_raw() }.encode(out);
+                self.rlp_encode_raw(out);
+            }
+
+            #[inline]
+            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+                $(RlpEncodable::rlp_encode(&self.$idx, out);)+
+            }
+
+            #[inline]
+            fn rlp_len_raw(&self) -> usize {
+                0usize $(+ RlpEncodable::rlp_len(&self.$idx))+
+            }
+        }
+    )+};
+}
+
+tuple_impls! {
+    (A 0),
+    (A 0, B 1),
+    (A 0, B 1, C 2),
+    (A 0, B 1, C 2, D 3),
+    (A 0, B 1, C 2, D 3, E 4),
+    (A 0, B 1, C 2, D 3, E 4, F 5),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11),
+}
+
 macro_rules! deref_impl {
     ($($(#[$attr:meta])* [$($gen:tt)*] $t:ty),+ $(,)?) => {$(
         $(#[$attr])*
@@ -249,6 +310,16 @@ macro_rules! deref_impl {
             #[inline]
             fn rlp_encode(&self, out: &mut Encoder<'_>) {
                 (**self).rlp_encode(out)
+            }
+
+            #[inline]
+            fn rlp_len_raw(&self) -> usize {
+                (**self).rlp_len_raw()
+            }
+
+            #[inline]
+            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+                (**self).rlp_encode_raw(out)
             }
         }
     )+};

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -12,20 +12,20 @@ use alloc::vec::Vec;
 use arrayvec::ArrayVec;
 
 /// An RLP encoder wrapping a [`BufMut`].
-pub struct Encoder<'a> {
-    out: &'a mut dyn BufMut,
+pub struct Encoder<T: BufMut> {
+    out: T,
 }
 
-impl core::fmt::Debug for Encoder<'_> {
+impl<T: BufMut> core::fmt::Debug for Encoder<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Encoder").finish_non_exhaustive()
     }
 }
 
-impl<'a> Encoder<'a> {
+impl<T: BufMut> Encoder<T> {
     /// Creates a new encoder wrapping the given buffer.
     #[inline]
-    pub fn new(out: &'a mut dyn BufMut) -> Self {
+    pub const fn new(out: T) -> Self {
         Self { out }
     }
 
@@ -45,14 +45,11 @@ impl<'a> Encoder<'a> {
 /// A type that can be encoded via RLP.
 pub trait RlpEncodable {
     /// Encodes the type into the `out` buffer.
-    fn rlp_encode(&self, out: &mut Encoder<'_>);
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>);
 
     /// Encodes this value without its outer RLP list header.
-    ///
-    /// The default implementation preserves the historical behavior by encoding the value normally.
-    /// Structured implementations may override this to emit their fields sequentially.
     #[inline]
-    fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode_raw<T: BufMut>(&self, out: &mut Encoder<T>) {
         self.rlp_encode(out);
     }
 
@@ -69,18 +66,8 @@ pub trait RlpEncodable {
     }
 
     /// Returns the length of this value when encoded without its outer RLP list header.
-    ///
-    /// The default implementation preserves the historical behavior by returning the normal encoded
-    /// length. Structured implementations may override this to return only their payload length.
-    #[inline]
-    fn rlp_len_raw(&self) -> usize {
-        self.rlp_len()
-    }
+    fn rlp_len_raw(&self) -> usize;
 }
-
-// The existence of this function makes the compiler catch if the RlpEncodable
-// trait is "object-safe" or not.
-fn _assert_trait_object(_b: &dyn RlpEncodable) {}
 
 /// Defines the max length of an [`RlpEncodable`] type as a const generic.
 ///
@@ -133,11 +120,16 @@ impl RlpEncodable for [u8] {
     }
 
     #[inline]
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         if self.len() != 1 || self[0] >= EMPTY_STRING_CODE {
             Header { list: false, payload_length: self.len() }.encode(out);
         }
         out.put_slice(self);
+    }
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -148,7 +140,12 @@ impl<T: ?Sized> RlpEncodable for PhantomData<T> {
     }
 
     #[inline]
-    fn rlp_encode(&self, _out: &mut Encoder<'_>) {}
+    fn rlp_encode<O: BufMut>(&self, _out: &mut Encoder<O>) {}
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        0
+    }
 }
 
 impl RlpEncodable for PhantomPinned {
@@ -158,7 +155,12 @@ impl RlpEncodable for PhantomPinned {
     }
 
     #[inline]
-    fn rlp_encode(&self, _out: &mut Encoder<'_>) {}
+    fn rlp_encode<T: BufMut>(&self, _out: &mut Encoder<T>) {}
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        0
+    }
 }
 
 impl<const N: usize> RlpEncodable for [u8; N] {
@@ -168,8 +170,13 @@ impl<const N: usize> RlpEncodable for [u8; N] {
     }
 
     #[inline]
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         self[..].rlp_encode(out);
+    }
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -184,8 +191,13 @@ impl RlpEncodable for str {
     }
 
     #[inline]
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         self.as_bytes().rlp_encode(out)
+    }
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -197,9 +209,14 @@ impl RlpEncodable for bool {
     }
 
     #[inline]
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         // inlined `(*self as u8).rlp_encode(out)`
         out.put_u8(if *self { 1 } else { EMPTY_STRING_CODE });
+    }
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -219,7 +236,7 @@ macro_rules! uint_impl {
             }
 
             #[inline]
-            fn rlp_encode(&self, out: &mut Encoder<'_>) {
+            fn rlp_encode<O: BufMut>(&self, out: &mut Encoder<O>) {
                 let x = *self;
                 if x == 0 {
                     out.put_u8(EMPTY_STRING_CODE);
@@ -231,6 +248,11 @@ macro_rules! uint_impl {
                     out.put_u8(EMPTY_STRING_CODE + be.len() as u8);
                     out.put_slice(be);
                 }
+            }
+
+            #[inline]
+            fn rlp_len_raw(&self) -> usize {
+                self.rlp_len()
             }
         }
 
@@ -250,8 +272,13 @@ impl<T: RlpEncodable> RlpEncodable for Vec<T> {
     }
 
     #[inline]
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<O: BufMut>(&self, out: &mut Encoder<O>) {
         encode_list(self, out)
+    }
+
+    #[inline]
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
@@ -265,13 +292,13 @@ macro_rules! tuple_impls {
             }
 
             #[inline]
-            fn rlp_encode(&self, out: &mut Encoder<'_>) {
+            fn rlp_encode<O: BufMut>(&self, out: &mut Encoder<O>) {
                 Header { list: true, payload_length: self.rlp_len_raw() }.encode(out);
                 self.rlp_encode_raw(out);
             }
 
             #[inline]
-            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+            fn rlp_encode_raw<O: BufMut>(&self, out: &mut Encoder<O>) {
                 $(RlpEncodable::rlp_encode(&self.$idx, out);)+
             }
 
@@ -308,7 +335,7 @@ macro_rules! deref_impl {
             }
 
             #[inline]
-            fn rlp_encode(&self, out: &mut Encoder<'_>) {
+            fn rlp_encode<O: BufMut>(&self, out: &mut Encoder<O>) {
                 (**self).rlp_encode(out)
             }
 
@@ -318,7 +345,7 @@ macro_rules! deref_impl {
             }
 
             #[inline]
-            fn rlp_encode_raw(&self, out: &mut Encoder<'_>) {
+            fn rlp_encode_raw<O: BufMut>(&self, out: &mut Encoder<O>) {
                 (**self).rlp_encode_raw(out)
             }
         }
@@ -358,11 +385,16 @@ mod std_support {
         }
 
         #[inline]
-        fn rlp_encode(&self, out: &mut Encoder<'_>) {
+        fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
             match self {
                 Self::V4(ip) => ip.rlp_encode(out),
                 Self::V6(ip) => ip.rlp_encode(out),
             }
+        }
+
+        #[inline]
+        fn rlp_len_raw(&self) -> usize {
+            self.rlp_len()
         }
     }
 
@@ -373,8 +405,13 @@ mod std_support {
         }
 
         #[inline]
-        fn rlp_encode(&self, out: &mut Encoder<'_>) {
+        fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
             self.octets().rlp_encode(out)
+        }
+
+        #[inline]
+        fn rlp_len_raw(&self) -> usize {
+            self.rlp_len()
         }
     }
 
@@ -385,8 +422,13 @@ mod std_support {
         }
 
         #[inline]
-        fn rlp_encode(&self, out: &mut Encoder<'_>) {
+        fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
             self.octets().rlp_encode(out)
+        }
+
+        #[inline]
+        fn rlp_len_raw(&self) -> usize {
+            self.rlp_len()
         }
     }
 }
@@ -433,10 +475,11 @@ where
 
 /// Encode a list of items.
 #[inline]
-pub fn encode_list<B, T>(values: &[B], out: &mut Encoder<'_>)
+pub fn encode_list<B, T, O>(values: &[B], out: &mut Encoder<O>)
 where
     B: Borrow<T>,
     T: ?Sized + RlpEncodable,
+    O: BufMut,
 {
     rlp_list_header(values).encode(out);
     for value in values {
@@ -448,11 +491,12 @@ where
 ///
 /// This clones the iterator. Prefer [`encode_list`] if possible.
 #[inline]
-pub fn encode_iter<I, B, T>(values: I, out: &mut Encoder<'_>)
+pub fn encode_iter<I, B, T, O>(values: I, out: &mut Encoder<O>)
 where
     I: Iterator<Item = B> + Clone,
     B: Borrow<T>,
     T: ?Sized + RlpEncodable,
+    O: BufMut,
 {
     let mut h = Header { list: true, payload_length: 0 };
     for t in values.clone() {

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -4,12 +4,10 @@ use core::fmt;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// RLP error with byte position context.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
-    /// The byte position in the input where the error occurred.
-    pub bytepos: usize,
-    /// The kind of error.
-    pub kind: ErrorKind,
+    bytepos: usize,
+    kind: ErrorKind,
 }
 
 impl Error {
@@ -23,6 +21,18 @@ impl Error {
     #[inline]
     pub const fn with_bytepos(kind: ErrorKind, bytepos: usize) -> Self {
         Self { bytepos, kind }
+    }
+
+    /// Returns the kind of error.
+    #[inline]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Returns the byte position in the input where the error occurred.
+    #[inline]
+    pub const fn bytepos(&self) -> usize {
+        self.bytepos
     }
 }
 
@@ -106,22 +116,22 @@ mod tests {
     #[test]
     fn error_new() {
         let e = Error::new(ErrorKind::Overflow);
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::Overflow);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::Overflow);
     }
 
     #[test]
     fn error_with_bytepos() {
         let e = Error::with_bytepos(ErrorKind::InputTooShort, 42);
-        assert_eq!(e.bytepos, 42);
-        assert_eq!(e.kind, ErrorKind::InputTooShort);
+        assert_eq!(e.bytepos(), 42);
+        assert_eq!(e.kind(), ErrorKind::InputTooShort);
     }
 
     #[test]
     fn error_from_error_kind() {
         let e: Error = ErrorKind::LeadingZero.into();
-        assert_eq!(e.bytepos, 0);
-        assert_eq!(e.kind, ErrorKind::LeadingZero);
+        assert_eq!(e.bytepos(), 0);
+        assert_eq!(e.kind(), ErrorKind::LeadingZero);
     }
 
     #[test]
@@ -150,11 +160,9 @@ mod tests {
     }
 
     #[test]
-    fn error_clone_copy() {
+    fn error_clone() {
         let e = Error::with_bytepos(ErrorKind::LeadingZero, 5);
-        let cloned = e;
-        let copied = e;
+        let cloned = e.clone();
         assert_eq!(e, cloned);
-        assert_eq!(e, copied);
     }
 }

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -1,7 +1,7 @@
 use crate::{
     decode::static_left_pad, Encoder, Error, ErrorKind, Result, EMPTY_LIST_CODE, EMPTY_STRING_CODE,
 };
-use bytes::Buf;
+use bytes::{Buf, BufMut};
 use core::hint::unreachable_unchecked;
 
 /// The header of an RLP item.
@@ -21,16 +21,35 @@ impl Header {
     /// Returns an error if the buffer is too short or the header is invalid.
     #[inline]
     pub fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Self::decode_at(buf, 0)
+    }
+
+    /// Decodes an RLP header from the given buffer using `bytepos` as the absolute
+    /// byte position of the first byte in `buf`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short or the header is invalid.
+    #[inline]
+    pub fn decode_at(buf: &mut &[u8], bytepos: usize) -> Result<Self> {
+        let started_len = buf.len();
         let payload_length;
         let mut list = false;
-        match get_next_byte(buf)? {
+        match get_next_byte(buf, started_len, bytepos)? {
             0..=0x7F => payload_length = 1,
 
             b @ EMPTY_STRING_CODE..=0xB7 => {
                 buf.advance(1);
                 payload_length = (b - EMPTY_STRING_CODE) as usize;
-                if payload_length == 1 && get_next_byte(buf)? < EMPTY_STRING_CODE {
-                    return Err(ErrorKind::NonCanonicalSingleByte.into());
+                if payload_length == 1
+                    && get_next_byte(buf, started_len, bytepos)? < EMPTY_STRING_CODE
+                {
+                    return Err(error_at(
+                        ErrorKind::NonCanonicalSingleByte,
+                        buf,
+                        started_len,
+                        bytepos,
+                    ));
                 }
             }
 
@@ -49,17 +68,21 @@ impl Header {
                 }
 
                 if buf.len() < len_of_len {
-                    return Err(ErrorKind::InputTooShort.into());
+                    return Err(error_at(ErrorKind::InputTooShort, buf, started_len, bytepos));
                 }
                 // SAFETY: length checked above
                 let len = unsafe { buf.get_unchecked(..len_of_len) };
+                let len_bytepos = current_bytepos(buf, started_len, bytepos);
                 buf.advance(len_of_len);
 
-                let len = u64::from_be_bytes(static_left_pad(len)?);
-                payload_length = usize::try_from(len)
-                    .map_err(|_| Error::new(ErrorKind::Custom("Input too big")))?;
+                let len = u64::from_be_bytes(static_left_pad(len).map_err(|err| {
+                    Error::with_bytepos(err.kind(), len_bytepos.saturating_add(err.bytepos()))
+                })?);
+                payload_length = usize::try_from(len).map_err(|_| {
+                    Error::with_bytepos(ErrorKind::Custom("Input too big"), len_bytepos)
+                })?;
                 if payload_length < 56 {
-                    return Err(ErrorKind::NonCanonicalSize.into());
+                    return Err(error_at(ErrorKind::NonCanonicalSize, buf, started_len, bytepos));
                 }
             }
 
@@ -71,7 +94,7 @@ impl Header {
         }
 
         if buf.remaining() < payload_length {
-            return Err(ErrorKind::InputTooShort.into());
+            return Err(error_at(ErrorKind::InputTooShort, buf, started_len, bytepos));
         }
 
         Ok(Self { list, payload_length })
@@ -84,14 +107,28 @@ impl Header {
     /// Returns an error if the buffer is too short or the header is invalid.
     #[inline]
     pub fn decode_bytes<'a>(buf: &mut &'a [u8], is_list: bool) -> Result<&'a [u8]> {
-        let Self { list, payload_length } = Self::decode(buf)?;
+        Self::decode_bytes_at(buf, is_list, 0)
+    }
+
+    /// Decodes the next payload from the given buffer using `bytepos` as the absolute
+    /// byte position of the first byte in `buf`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short or the header is invalid.
+    #[inline]
+    pub fn decode_bytes_at<'a>(
+        buf: &mut &'a [u8],
+        is_list: bool,
+        bytepos: usize,
+    ) -> Result<&'a [u8]> {
+        let Self { list, payload_length } = Self::decode_at(buf, bytepos)?;
 
         if list != is_list {
-            return Err(if is_list {
-                ErrorKind::UnexpectedString.into()
-            } else {
-                ErrorKind::UnexpectedList.into()
-            });
+            return Err(Error::with_bytepos(
+                if is_list { ErrorKind::UnexpectedString } else { ErrorKind::UnexpectedList },
+                bytepos,
+            ));
         }
 
         // SAFETY: this is already checked in `decode`
@@ -106,8 +143,24 @@ impl Header {
     /// Returns an error if the buffer is too short or the header is invalid.
     #[inline]
     pub fn decode_str<'a>(buf: &mut &'a [u8]) -> Result<&'a str> {
-        let bytes = Self::decode_bytes(buf, false)?;
-        core::str::from_utf8(bytes).map_err(|_| Error::new(ErrorKind::Custom("invalid string")))
+        Self::decode_str_at(buf, 0)
+    }
+
+    /// Decodes a string slice from the given buffer using `bytepos` as the absolute
+    /// byte position of the first byte in `buf`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short, the header is invalid, or the
+    /// decoded bytes are not valid UTF-8.
+    #[inline]
+    pub fn decode_str_at<'a>(buf: &mut &'a [u8], bytepos: usize) -> Result<&'a str> {
+        let started_len = buf.len();
+        let bytes = Self::decode_bytes_at(buf, false, bytepos)?;
+        let consumed = started_len.saturating_sub(buf.len());
+        let payload_bytepos = bytepos.saturating_add(consumed.saturating_sub(bytes.len()));
+        core::str::from_utf8(bytes)
+            .map_err(|_| Error::with_bytepos(ErrorKind::Custom("invalid string"), payload_bytepos))
     }
 
     /// Extracts the next payload from the given buffer, advancing it.
@@ -123,7 +176,26 @@ impl Header {
     /// - Any nested headers (for list items) are invalid
     #[inline]
     pub fn decode_raw<'a>(buf: &mut &'a [u8]) -> Result<PayloadView<'a>> {
-        let Self { list, payload_length } = Self::decode(buf)?;
+        Self::decode_raw_at(buf, 0)
+    }
+
+    /// Extracts the next payload from the given buffer using `bytepos` as the absolute
+    /// byte position of the first byte in `buf`.
+    ///
+    /// The returned `PayloadView` provides a structured view of the payload, allowing for efficient
+    /// parsing of nested items without unnecessary allocations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The buffer is too short
+    /// - The header is invalid
+    /// - Any nested headers (for list items) are invalid
+    #[inline]
+    pub fn decode_raw_at<'a>(buf: &mut &'a [u8], bytepos: usize) -> Result<PayloadView<'a>> {
+        let started_len = buf.len();
+        let Self { list, payload_length } = Self::decode_at(buf, bytepos)?;
+        let payload_bytepos = bytepos.saturating_add(started_len.saturating_sub(buf.len()));
         // SAFETY: this is already checked in `decode`
         let mut payload = unsafe { advance_unchecked(buf, payload_length) };
 
@@ -132,12 +204,13 @@ impl Header {
         }
 
         let mut items = alloc::vec::Vec::new();
+        let mut item_bytepos = payload_bytepos;
         while !payload.is_empty() {
             // store the start of the current item for later slice creation
             let item_start = payload;
 
             // decode the header of the next RLP item, advancing the payload
-            let Self { payload_length, .. } = Self::decode(&mut payload)?;
+            let Self { payload_length, .. } = Self::decode_at(&mut payload, item_bytepos)?;
             // SAFETY: this is already checked in `decode`
             unsafe { advance_unchecked(&mut payload, payload_length) };
 
@@ -145,6 +218,7 @@ impl Header {
             // remaining payload length from the initial length
             let item_length = item_start.len() - payload.len();
             items.push(&item_start[..item_length]);
+            item_bytepos = item_bytepos.saturating_add(item_length);
         }
 
         Ok(PayloadView::List(items))
@@ -152,7 +226,7 @@ impl Header {
 
     /// Encodes the header into the `out` buffer.
     #[inline]
-    pub fn encode(&self, out: &mut Encoder<'_>) {
+    pub fn encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         if self.payload_length < 56 {
             let code = if self.list { EMPTY_LIST_CODE } else { EMPTY_STRING_CODE };
             out.put_u8(code + self.payload_length as u8);
@@ -188,12 +262,22 @@ pub enum PayloadView<'a> {
 
 /// Same as `buf.first().ok_or(ErrorKind::InputTooShort)`.
 #[inline(always)]
-fn get_next_byte(buf: &[u8]) -> Result<u8> {
+fn get_next_byte(buf: &[u8], started_len: usize, bytepos: usize) -> Result<u8> {
     if buf.is_empty() {
-        return Err(ErrorKind::InputTooShort.into());
+        return Err(error_at(ErrorKind::InputTooShort, &buf, started_len, bytepos));
     }
     // SAFETY: length checked above
     Ok(*unsafe { buf.get_unchecked(0) })
+}
+
+#[inline(always)]
+const fn error_at(kind: ErrorKind, buf: &&[u8], started_len: usize, bytepos: usize) -> Error {
+    Error::with_bytepos(kind, current_bytepos(buf, started_len, bytepos))
+}
+
+#[inline(always)]
+const fn current_bytepos(buf: &&[u8], started_len: usize, bytepos: usize) -> usize {
+    bytepos.saturating_add(started_len.saturating_sub(buf.len()))
 }
 
 /// Same as `let (bytes, rest) = buf.split_at(cnt); *buf = rest; bytes`.
@@ -257,5 +341,28 @@ mod tests {
         check_decode_raw_string("");
         check_decode_raw_string(" ");
         check_decode_raw_string("test1234");
+    }
+
+    #[test]
+    fn decode_at_reports_absolute_byte_positions() {
+        let mut input = &[0x82][..];
+        let err = Header::decode_at(&mut input, 7).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InputTooShort);
+        assert_eq!(err.bytepos(), 8);
+
+        let mut input = &[0xc0][..];
+        let err = Header::decode_bytes_at(&mut input, false, 11).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedList);
+        assert_eq!(err.bytepos(), 11);
+
+        let mut input = &[0x81, 0xff][..];
+        let err = Header::decode_str_at(&mut input, 13).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Custom("invalid string"));
+        assert_eq!(err.bytepos(), 14);
+
+        let mut input = &[0xc2, 0x01, 0x82][..];
+        let err = Header::decode_raw_at(&mut input, 17).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InputTooShort);
+        assert_eq!(err.bytepos(), 20);
     }
 }

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{decode_exact, Rlp, RlpDecodable};
+pub use decode::{decode_exact, Decoder, Rlp, RlpDecodable};
 
 mod error;
 pub use error::{Error, ErrorKind, Result};

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -49,6 +49,7 @@ pub type DecodeError = ErrorKind;
 
 #[doc(hidden)]
 pub mod private {
+    pub use crate::decode::decode_optional_raw;
     pub use core::{
         default::Default,
         option::Option::{self, None, Some},

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -19,6 +19,27 @@ where
     alloy_rlp::decode_exact(bytes)
 }
 
+fn manual_list(fields: &[Vec<u8>]) -> Vec<u8> {
+    let payload_length = fields.iter().map(Vec::len).sum();
+    let mut out = Vec::new();
+    Header { list: true, payload_length }.encode(&mut Encoder::new(&mut out));
+    for field in fields {
+        out.extend_from_slice(field);
+    }
+    out
+}
+
+fn assert_manual_list_encoding<T>(value: &T, fields: &[Vec<u8>])
+where
+    T: RlpEncodable + for<'de> RlpDecodable<'de> + PartialEq + std::fmt::Debug,
+{
+    let encoded = alloy_rlp::encode(value);
+    assert_eq!(encoded, manual_list(fields));
+
+    let decoded = decode::<T>(&encoded).unwrap();
+    assert_eq!(&decoded, value);
+}
+
 #[test]
 fn simple_derive() {
     #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
@@ -538,4 +559,211 @@ fn transparent_structs_encode_as_inner_field() {
         decode::<WithSkip>(alloy_rlp::encode(42u64)).unwrap(),
         WithSkip { value: 42, marker: Marker }
     );
+}
+
+#[test]
+fn reth_like_eth_payloads_match_manual_list_encoding() {
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct BlockHashNumber {
+        hash: [u8; 32],
+        number: u64,
+    }
+
+    let block_hash_number = BlockHashNumber { hash: [0x11; 32], number: 17 };
+    assert_manual_list_encoding(
+        &block_hash_number,
+        &[alloy_rlp::encode(block_hash_number.hash), alloy_rlp::encode(block_hash_number.number)],
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct LegacyTx {
+        nonce: u64,
+        gas_price: u128,
+        gas_limit: u64,
+        to: [u8; 20],
+        value: u128,
+        input: Bytes,
+        v: u64,
+        r: u128,
+        s: u128,
+    }
+
+    let tx = LegacyTx {
+        nonce: 7,
+        gas_price: 20_000_000_000,
+        gas_limit: 21_000,
+        to: [0x22; 20],
+        value: 1_000_000_000_000_000_000,
+        input: Bytes::from_static(b"call-data"),
+        v: 37,
+        r: 0x1234,
+        s: 0x5678,
+    };
+    assert_manual_list_encoding(
+        &tx,
+        &[
+            alloy_rlp::encode(tx.nonce),
+            alloy_rlp::encode(tx.gas_price),
+            alloy_rlp::encode(tx.gas_limit),
+            alloy_rlp::encode(tx.to),
+            alloy_rlp::encode(tx.value),
+            alloy_rlp::encode(&tx.input),
+            alloy_rlp::encode(tx.v),
+            alloy_rlp::encode(tx.r),
+            alloy_rlp::encode(tx.s),
+        ],
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct MiniHeader {
+        parent_hash: [u8; 32],
+        ommers_hash: [u8; 32],
+        beneficiary: [u8; 20],
+        state_root: [u8; 32],
+        transactions_root: [u8; 32],
+        receipts_root: [u8; 32],
+        logs_bloom: Bytes,
+        difficulty: u128,
+        number: u64,
+        gas_limit: u64,
+        gas_used: u64,
+        timestamp: u64,
+        extra_data: Bytes,
+        mix_hash: [u8; 32],
+        nonce: [u8; 8],
+    }
+
+    let header = MiniHeader {
+        parent_hash: [0x01; 32],
+        ommers_hash: [0x02; 32],
+        beneficiary: [0x03; 20],
+        state_root: [0x04; 32],
+        transactions_root: [0x05; 32],
+        receipts_root: [0x06; 32],
+        logs_bloom: Bytes::from(vec![0xaa; 256]),
+        difficulty: 17_000_000,
+        number: 18_000_000,
+        gas_limit: 30_000_000,
+        gas_used: 12_345_678,
+        timestamp: 1_700_000_000,
+        extra_data: Bytes::from_static(b"alloy-rlp"),
+        mix_hash: [0x07; 32],
+        nonce: [0x08; 8],
+    };
+    assert_manual_list_encoding(
+        &header,
+        &[
+            alloy_rlp::encode(header.parent_hash),
+            alloy_rlp::encode(header.ommers_hash),
+            alloy_rlp::encode(header.beneficiary),
+            alloy_rlp::encode(header.state_root),
+            alloy_rlp::encode(header.transactions_root),
+            alloy_rlp::encode(header.receipts_root),
+            alloy_rlp::encode(&header.logs_bloom),
+            alloy_rlp::encode(header.difficulty),
+            alloy_rlp::encode(header.number),
+            alloy_rlp::encode(header.gas_limit),
+            alloy_rlp::encode(header.gas_used),
+            alloy_rlp::encode(header.timestamp),
+            alloy_rlp::encode(&header.extra_data),
+            alloy_rlp::encode(header.mix_hash),
+            alloy_rlp::encode(header.nonce),
+        ],
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct MiniBlock {
+        header: MiniHeader,
+        transactions: Vec<LegacyTx>,
+        ommers: Vec<MiniHeader>,
+    }
+
+    let ommer = MiniHeader { nonce: [0x09; 8], ..header.clone() };
+    let block = MiniBlock { header, transactions: vec![tx.clone()], ommers: vec![ommer] };
+    assert_manual_list_encoding(
+        &block,
+        &[
+            alloy_rlp::encode(&block.header),
+            alloy_rlp::encode(&block.transactions),
+            alloy_rlp::encode(&block.ommers),
+        ],
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct NewBlock {
+        block: MiniBlock,
+        td: u128,
+    }
+
+    let new_block = NewBlock { block, td: 19_000_000 };
+    assert_manual_list_encoding(
+        &new_block,
+        &[alloy_rlp::encode(&new_block.block), alloy_rlp::encode(new_block.td)],
+    );
+
+    #[derive(RlpEncodableWrapper, RlpDecodableWrapper, PartialEq, Debug)]
+    struct Transactions(Vec<LegacyTx>);
+
+    let transactions = Transactions(vec![tx]);
+    let encoded = alloy_rlp::encode(&transactions);
+    assert_eq!(encoded, alloy_rlp::encode(&transactions.0));
+    assert_eq!(decode::<Transactions>(&encoded).unwrap(), transactions);
+}
+
+#[test]
+fn reth_like_p2p_tagged_payloads_match_manual_list_encoding() {
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct Capability {
+        name: String,
+        version: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, Clone, PartialEq, Debug)]
+    struct HelloMessage {
+        protocol_version: u64,
+        client_version: String,
+        capabilities: Vec<Capability>,
+        port: u16,
+        id: [u8; 32],
+    }
+
+    let hello = HelloMessage {
+        protocol_version: 5,
+        client_version: "reth/v1.0.0".to_string(),
+        capabilities: vec![Capability { name: "eth".to_string(), version: 68 }],
+        port: 30303,
+        id: [0x42; 32],
+    };
+    assert_manual_list_encoding(
+        &hello,
+        &[
+            alloy_rlp::encode(hello.protocol_version),
+            alloy_rlp::encode(&hello.client_version),
+            alloy_rlp::encode(&hello.capabilities),
+            alloy_rlp::encode(hello.port),
+            alloy_rlp::encode(hello.id),
+        ],
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum P2PControl {
+        Hello(HelloMessage),
+        Disconnect {
+            reason: u8,
+        },
+        #[rlp(tag = 2)]
+        Ping,
+        #[rlp(tag = 3)]
+        Pong,
+    }
+
+    let hello_msg = P2PControl::Hello(hello.clone());
+    assert_manual_list_encoding(&hello_msg, &[alloy_rlp::encode(0u64), alloy_rlp::encode(&hello)]);
+
+    let disconnect = P2PControl::Disconnect { reason: 8 };
+    assert_manual_list_encoding(&disconnect, &[alloy_rlp::encode(1u64), alloy_rlp::encode(8u8)]);
+
+    assert_manual_list_encoding(&P2PControl::Ping, &[alloy_rlp::encode(2u64)]);
+    assert_manual_list_encoding(&P2PControl::Pong, &[alloy_rlp::encode(3u64)]);
 }

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -5,6 +5,13 @@
 
 use alloy_rlp::*;
 
+fn assert_err_kind<T>(result: alloy_rlp::Result<T>, expected: ErrorKind) {
+    match result {
+        Ok(_) => panic!("expected {expected:?} error"),
+        Err(err) => assert_eq!(err.kind(), expected),
+    }
+}
+
 #[test]
 fn simple_derive() {
     #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
@@ -134,4 +141,358 @@ fn skip_field() {
 
     let decoded = WithoutSkip::rlp_decode(&mut buf.as_slice()).unwrap();
     assert_eq!(decoded.value, 42);
+}
+
+#[test]
+fn tuple_roundtrips_and_raw_modes() {
+    fn check<T>(value: T)
+    where
+        T: RlpEncodable + RlpDecodable + PartialEq + std::fmt::Debug,
+    {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(encoded.len(), value.rlp_len());
+        let decoded = T::rlp_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded, value);
+
+        let mut raw = Vec::new();
+        value.rlp_encode_raw(&mut Encoder::new(&mut raw));
+        assert_eq!(raw.len(), value.rlp_len_raw());
+        let mut raw_slice = raw.as_slice();
+        let decoded_raw = T::rlp_decode_raw(&mut raw_slice).unwrap();
+        assert_eq!(decoded_raw, value);
+        assert!(raw_slice.is_empty());
+        assert_ne!(encoded, raw);
+    }
+
+    check((1u8,));
+    check((1u8, 2u16));
+    check((1u8, 2u16, 3u32));
+    check((1u8, 2u16, 3u32, 4u64));
+    check((1u8, 2u16, 3u32, 4u64, 5usize));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1]));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1], [8u8; 2]));
+    check((1u8, 2u16, 3u32, 4u64, 5usize, 6u128, true, [7u8; 1], [8u8; 2], String::from("nine")));
+    check((
+        1u8,
+        2u16,
+        3u32,
+        4u64,
+        5usize,
+        6u128,
+        true,
+        [7u8; 1],
+        [8u8; 2],
+        String::from("nine"),
+        Bytes::from(vec![10u8]),
+    ));
+    check((
+        1u8,
+        2u16,
+        3u32,
+        4u64,
+        5usize,
+        6u128,
+        true,
+        [7u8; 1],
+        [8u8; 2],
+        String::from("nine"),
+        Bytes::from(vec![10u8]),
+        BytesMut::from(&b"eleven"[..]),
+    ));
+}
+
+#[test]
+fn tuple_decode_rejects_malformed_lists() {
+    let too_few = alloy_rlp::encode((1u8,));
+    assert_err_kind(<(u8, u8)>::rlp_decode(&mut too_few.as_slice()), ErrorKind::InputTooShort);
+
+    let extra = alloy_rlp::encode((1u8, 2u8));
+    assert_err_kind(
+        <(u8,)>::rlp_decode(&mut extra.as_slice()),
+        ErrorKind::ListLengthMismatch { expected: 2, got: 1 },
+    );
+
+    assert_err_kind(<(u8,)>::rlp_decode(&mut [0x01].as_slice()), ErrorKind::UnexpectedString);
+}
+
+#[test]
+fn tuple_raw_decode_leaves_outer_fields() {
+    let mut raw = Vec::new();
+    (1u8, 2u8).rlp_encode_raw(&mut Encoder::new(&mut raw));
+    3u8.rlp_encode(&mut Encoder::new(&mut raw));
+
+    let mut slice = raw.as_slice();
+    let tuple = <(u8, u8)>::rlp_decode_raw(&mut slice).unwrap();
+    let tail = u8::rlp_decode(&mut slice).unwrap();
+    assert_eq!(tuple, (1, 2));
+    assert_eq!(tail, 3);
+    assert!(slice.is_empty());
+}
+
+#[test]
+fn flatten_nested_vs_flat_encoding() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+        b: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterNested {
+        x: u64,
+        inner: Inner,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct OuterFlat {
+        x: u64,
+        #[rlp(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Equivalent {
+        x: u64,
+        a: u64,
+        b: u64,
+    }
+
+    let nested = OuterNested { x: 1, inner: Inner { a: 2, b: 3 } };
+    let flat = OuterFlat { x: 1, inner: Inner { a: 2, b: 3 } };
+    let equivalent = Equivalent { x: 1, a: 2, b: 3 };
+
+    let nested_encoded = alloy_rlp::encode(&nested);
+    let flat_encoded = alloy_rlp::encode(&flat);
+    assert_ne!(nested_encoded, flat_encoded);
+    assert_eq!(flat_encoded, alloy_rlp::encode(&equivalent));
+    assert_eq!(OuterFlat::rlp_decode(&mut flat_encoded.as_slice()).unwrap(), flat);
+}
+
+#[test]
+fn flatten_multiple_and_tuple_fields() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct A {
+        x: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct B {
+        y: u16,
+        z: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Combined {
+        #[rlp(flatten)]
+        a: A,
+        #[rlp(flatten)]
+        pair: (u8, u16),
+        #[rlp(flatten)]
+        b: B,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        x: u64,
+        pair_0: u8,
+        pair_1: u16,
+        y: u16,
+        z: u64,
+    }
+
+    let value = Combined { a: A { x: 10 }, pair: (11, 12), b: B { y: 20, z: 30 } };
+    let flat = Flat { x: 10, pair_0: 11, pair_1: 12, y: 20, z: 30 };
+
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&flat));
+    assert_eq!(Combined::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+}
+
+#[test]
+fn flatten_with_skip_default_fields() {
+    #[derive(PartialEq, Debug, Default)]
+    struct Cache(u64);
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Inner {
+        a: u64,
+        #[rlp(default, skip)]
+        cache: Cache,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Outer {
+        #[rlp(flatten)]
+        inner: Inner,
+        b: u64,
+        #[rlp(skip)]
+        cache: Cache,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        a: u64,
+        b: u64,
+    }
+
+    let value = Outer { inner: Inner { a: 1, cache: Cache(2) }, b: 3, cache: Cache(4) };
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, b: 3 }));
+
+    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded.inner.a, 1);
+    assert_eq!(decoded.inner.cache, Cache::default());
+    assert_eq!(decoded.b, 3);
+    assert_eq!(decoded.cache, Cache::default());
+}
+
+#[test]
+fn trailing_optional_last_field_roundtrips_zero() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing)]
+    struct S {
+        x: u64,
+        y: Option<u64>,
+    }
+
+    for value in [S { x: 1, y: None }, S { x: 1, y: Some(0) }, S { x: 1, y: Some(2) }] {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(S::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+    }
+}
+
+#[test]
+fn flattened_trailing_options_do_not_consume_outer_fields() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing)]
+    struct Inner {
+        a: u64,
+        maybe: Option<u64>,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Outer {
+        #[rlp(flatten)]
+        inner: Inner,
+        tail: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct Flat {
+        a: u64,
+        tail: u64,
+    }
+
+    let value = Outer { inner: Inner { a: 1, maybe: Some(2) }, tail: 3 };
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, tail: 3 }));
+
+    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(decoded, Outer { inner: Inner { a: 1, maybe: None }, tail: 3 });
+}
+
+#[test]
+fn tagged_enum_roundtrips_shapes_and_tags() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Message {
+        Ping,
+        Pong(u8, u16),
+        Data { a: u8, b: u64 },
+    }
+
+    for value in [Message::Ping, Message::Pong(1, 2), Message::Data { a: 3, b: 4 }] {
+        let encoded = alloy_rlp::encode(&value);
+        assert_eq!(Message::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Discriminants {
+        Start = 10,
+        Stop = 20,
+    }
+
+    assert_eq!(alloy_rlp::encode(&Discriminants::Start), alloy_rlp::encode((10u64,)));
+    assert_eq!(alloy_rlp::encode(&Discriminants::Stop), alloy_rlp::encode((20u64,)));
+    assert_eq!(
+        Discriminants::rlp_decode(&mut alloy_rlp::encode((10u64,)).as_slice()).unwrap(),
+        Discriminants::Start
+    );
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Custom {
+        #[rlp(tag = 0x80)]
+        Alpha,
+        #[rlp(tag = 0x1234)]
+        Beta(u64),
+    }
+
+    assert_eq!(alloy_rlp::encode(&Custom::Alpha), alloy_rlp::encode((0x80u64,)));
+    let beta = Custom::Beta(99);
+    let encoded = alloy_rlp::encode(&beta);
+    assert_eq!(Custom::rlp_decode(&mut encoded.as_slice()).unwrap(), beta);
+}
+
+#[test]
+fn tagged_enum_rejects_unknown_tags_and_trailing_payload() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Command {
+        Start = 10,
+    }
+
+    assert_err_kind(
+        Command::rlp_decode(&mut alloy_rlp::encode((99u64,)).as_slice()),
+        ErrorKind::Custom("unknown variant tag"),
+    );
+    assert_err_kind(
+        Command::rlp_decode(&mut alloy_rlp::encode((10u64, 1u8)).as_slice()),
+        ErrorKind::ListLengthMismatch { expected: 0, got: 1 },
+    );
+}
+
+#[test]
+fn transparent_structs_encode_as_inner_field() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Named {
+        inner: u64,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct Newtype(u64);
+
+    #[derive(PartialEq, Debug, Default)]
+    struct Marker;
+
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(transparent)]
+    struct WithSkip {
+        value: u64,
+        #[rlp(skip)]
+        marker: Marker,
+    }
+
+    for encoded in [
+        alloy_rlp::encode(Named { inner: 42 }),
+        alloy_rlp::encode(Newtype(42)),
+        alloy_rlp::encode(WithSkip { value: 42, marker: Marker }),
+    ] {
+        assert_eq!(encoded, alloy_rlp::encode(42u64));
+    }
+
+    assert_eq!(
+        Named::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
+        Named { inner: 42 }
+    );
+    assert_eq!(Newtype::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(), Newtype(42));
+    assert_eq!(
+        WithSkip::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
+        WithSkip { value: 42, marker: Marker }
+    );
 }

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -12,6 +12,13 @@ fn assert_err_kind<T>(result: alloy_rlp::Result<T>, expected: ErrorKind) {
     }
 }
 
+fn decode<T>(bytes: impl AsRef<[u8]>) -> alloy_rlp::Result<T>
+where
+    T: for<'de> RlpDecodable<'de>,
+{
+    alloy_rlp::decode_exact(bytes)
+}
+
 #[test]
 fn simple_derive() {
     #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
@@ -22,14 +29,11 @@ fn simple_derive() {
     // roundtrip fidelity
     let mut buf = Vec::new();
     thing.rlp_encode(&mut Encoder::new(&mut buf));
-    let decoded = MyThing::rlp_decode(&mut buf.as_slice()).unwrap();
+    let decoded = decode::<MyThing>(&buf).unwrap();
     assert_eq!(thing, decoded);
 
     // does not panic on short input
-    assert_eq!(
-        Err(Error::new(ErrorKind::InputTooShort)),
-        MyThing::rlp_decode(&mut [0x8c; 11].as_ref())
-    )
+    assert_err_kind(decode::<MyThing>([0x8c; 11]), ErrorKind::InputTooShort)
 }
 
 #[test]
@@ -93,7 +97,7 @@ fn multiple_attrs_combined() {
     let mut buf = Vec::new();
     foo.rlp_encode(&mut Encoder::new(&mut buf));
 
-    let decoded = Foo::rlp_decode(&mut buf.as_slice()).unwrap();
+    let decoded = decode::<Foo>(&buf).unwrap();
     assert_eq!(decoded.bar, 42);
     assert_eq!(decoded.cache, Cache::default());
 
@@ -110,7 +114,7 @@ fn multiple_attrs_combined() {
     let mut buf2 = Vec::new();
     bar.rlp_encode(&mut Encoder::new(&mut buf2));
 
-    let decoded2 = Bar::rlp_decode(&mut buf2.as_slice()).unwrap();
+    let decoded2 = decode::<Bar>(&buf2).unwrap();
     assert_eq!(decoded2.baz, 99);
     assert_eq!(decoded2.cache, Cache::default());
 }
@@ -139,7 +143,7 @@ fn skip_field() {
         pub value: u64,
     }
 
-    let decoded = WithoutSkip::rlp_decode(&mut buf.as_slice()).unwrap();
+    let decoded = decode::<WithoutSkip>(&buf).unwrap();
     assert_eq!(decoded.value, 42);
 }
 
@@ -147,20 +151,20 @@ fn skip_field() {
 fn tuple_roundtrips_and_raw_modes() {
     fn check<T>(value: T)
     where
-        T: RlpEncodable + RlpDecodable + PartialEq + std::fmt::Debug,
+        T: RlpEncodable + for<'de> RlpDecodable<'de> + PartialEq + std::fmt::Debug,
     {
         let encoded = alloy_rlp::encode(&value);
         assert_eq!(encoded.len(), value.rlp_len());
-        let decoded = T::rlp_decode(&mut encoded.as_slice()).unwrap();
+        let decoded = decode::<T>(&encoded).unwrap();
         assert_eq!(decoded, value);
 
         let mut raw = Vec::new();
         value.rlp_encode_raw(&mut Encoder::new(&mut raw));
         assert_eq!(raw.len(), value.rlp_len_raw());
-        let mut raw_slice = raw.as_slice();
-        let decoded_raw = T::rlp_decode_raw(&mut raw_slice).unwrap();
+        let mut raw_decoder = Decoder::new(&raw);
+        let decoded_raw = T::rlp_decode_raw(&mut raw_decoder).unwrap();
         assert_eq!(decoded_raw, value);
-        assert!(raw_slice.is_empty());
+        assert!(raw_decoder.is_empty());
         assert_ne!(encoded, raw);
     }
 
@@ -206,15 +210,12 @@ fn tuple_roundtrips_and_raw_modes() {
 #[test]
 fn tuple_decode_rejects_malformed_lists() {
     let too_few = alloy_rlp::encode((1u8,));
-    assert_err_kind(<(u8, u8)>::rlp_decode(&mut too_few.as_slice()), ErrorKind::InputTooShort);
+    assert_err_kind(decode::<(u8, u8)>(&too_few), ErrorKind::InputTooShort);
 
     let extra = alloy_rlp::encode((1u8, 2u8));
-    assert_err_kind(
-        <(u8,)>::rlp_decode(&mut extra.as_slice()),
-        ErrorKind::ListLengthMismatch { expected: 2, got: 1 },
-    );
+    assert_err_kind(decode::<(u8,)>(&extra), ErrorKind::ListLengthMismatch { expected: 2, got: 1 });
 
-    assert_err_kind(<(u8,)>::rlp_decode(&mut [0x01].as_slice()), ErrorKind::UnexpectedString);
+    assert_err_kind(decode::<(u8,)>([0x01]), ErrorKind::UnexpectedString);
 }
 
 #[test]
@@ -223,12 +224,12 @@ fn tuple_raw_decode_leaves_outer_fields() {
     (1u8, 2u8).rlp_encode_raw(&mut Encoder::new(&mut raw));
     3u8.rlp_encode(&mut Encoder::new(&mut raw));
 
-    let mut slice = raw.as_slice();
-    let tuple = <(u8, u8)>::rlp_decode_raw(&mut slice).unwrap();
-    let tail = u8::rlp_decode(&mut slice).unwrap();
+    let mut decoder = Decoder::new(&raw);
+    let tuple = <(u8, u8)>::rlp_decode_raw(&mut decoder).unwrap();
+    let tail = u8::rlp_decode(&mut decoder).unwrap();
     assert_eq!(tuple, (1, 2));
     assert_eq!(tail, 3);
-    assert!(slice.is_empty());
+    assert!(decoder.is_empty());
 }
 
 #[test]
@@ -267,7 +268,7 @@ fn flatten_nested_vs_flat_encoding() {
     let flat_encoded = alloy_rlp::encode(&flat);
     assert_ne!(nested_encoded, flat_encoded);
     assert_eq!(flat_encoded, alloy_rlp::encode(&equivalent));
-    assert_eq!(OuterFlat::rlp_decode(&mut flat_encoded.as_slice()).unwrap(), flat);
+    assert_eq!(decode::<OuterFlat>(&flat_encoded).unwrap(), flat);
 }
 
 #[test]
@@ -307,7 +308,7 @@ fn flatten_multiple_and_tuple_fields() {
 
     let encoded = alloy_rlp::encode(&value);
     assert_eq!(encoded, alloy_rlp::encode(&flat));
-    assert_eq!(Combined::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+    assert_eq!(decode::<Combined>(&encoded).unwrap(), value);
 }
 
 #[test]
@@ -341,7 +342,7 @@ fn flatten_with_skip_default_fields() {
     let encoded = alloy_rlp::encode(&value);
     assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, b: 3 }));
 
-    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
+    let decoded = decode::<Outer>(&encoded).unwrap();
     assert_eq!(decoded.inner.a, 1);
     assert_eq!(decoded.inner.cache, Cache::default());
     assert_eq!(decoded.b, 3);
@@ -359,7 +360,7 @@ fn trailing_optional_last_field_roundtrips_zero() {
 
     for value in [S { x: 1, y: None }, S { x: 1, y: Some(0) }, S { x: 1, y: Some(2) }] {
         let encoded = alloy_rlp::encode(&value);
-        assert_eq!(S::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+        assert_eq!(decode::<S>(&encoded).unwrap(), value);
     }
 }
 
@@ -370,6 +371,7 @@ fn flattened_trailing_options_do_not_consume_outer_fields() {
     struct Inner {
         a: u64,
         maybe: Option<u64>,
+        later: Option<u64>,
     }
 
     #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
@@ -382,15 +384,34 @@ fn flattened_trailing_options_do_not_consume_outer_fields() {
     #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
     struct Flat {
         a: u64,
+        maybe: u64,
+        later: u64,
         tail: u64,
     }
 
-    let value = Outer { inner: Inner { a: 1, maybe: Some(2) }, tail: 3 };
-    let encoded = alloy_rlp::encode(&value);
-    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, tail: 3 }));
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    struct FlatWithoutLater {
+        a: u64,
+        maybe: u64,
+        tail: u64,
+    }
 
-    let decoded = Outer::rlp_decode(&mut encoded.as_slice()).unwrap();
-    assert_eq!(decoded, Outer { inner: Inner { a: 1, maybe: None }, tail: 3 });
+    let value = Outer { inner: Inner { a: 1, maybe: Some(2), later: Some(4) }, tail: 3 };
+    let encoded = alloy_rlp::encode(&value);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, maybe: 2, later: 4, tail: 3 }));
+
+    let decoded = decode::<Outer>(&encoded).unwrap();
+    assert_eq!(decoded, value);
+
+    let zero_then_tail = Outer { inner: Inner { a: 1, maybe: Some(0), later: None }, tail: 3 };
+    let encoded = alloy_rlp::encode(&zero_then_tail);
+    assert_eq!(encoded, alloy_rlp::encode(&FlatWithoutLater { a: 1, maybe: 0, tail: 3 }));
+    assert_eq!(decode::<Outer>(&encoded).unwrap(), zero_then_tail);
+
+    let sentinel_then_some = Outer { inner: Inner { a: 1, maybe: None, later: Some(2) }, tail: 3 };
+    let encoded = alloy_rlp::encode(&sentinel_then_some);
+    assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, maybe: 0, later: 2, tail: 3 }));
+    assert_eq!(decode::<Outer>(&encoded).unwrap(), sentinel_then_some);
 }
 
 #[test]
@@ -405,7 +426,7 @@ fn tagged_enum_roundtrips_shapes_and_tags() {
 
     for value in [Message::Ping, Message::Pong(1, 2), Message::Data { a: 3, b: 4 }] {
         let encoded = alloy_rlp::encode(&value);
-        assert_eq!(Message::rlp_decode(&mut encoded.as_slice()).unwrap(), value);
+        assert_eq!(decode::<Message>(&encoded).unwrap(), value);
     }
 
     #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
@@ -417,10 +438,7 @@ fn tagged_enum_roundtrips_shapes_and_tags() {
 
     assert_eq!(alloy_rlp::encode(&Discriminants::Start), alloy_rlp::encode((10u64,)));
     assert_eq!(alloy_rlp::encode(&Discriminants::Stop), alloy_rlp::encode((20u64,)));
-    assert_eq!(
-        Discriminants::rlp_decode(&mut alloy_rlp::encode((10u64,)).as_slice()).unwrap(),
-        Discriminants::Start
-    );
+    assert_eq!(decode::<Discriminants>(alloy_rlp::encode((10u64,))).unwrap(), Discriminants::Start);
 
     #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
     #[rlp(tagged)]
@@ -434,7 +452,7 @@ fn tagged_enum_roundtrips_shapes_and_tags() {
     assert_eq!(alloy_rlp::encode(&Custom::Alpha), alloy_rlp::encode((0x80u64,)));
     let beta = Custom::Beta(99);
     let encoded = alloy_rlp::encode(&beta);
-    assert_eq!(Custom::rlp_decode(&mut encoded.as_slice()).unwrap(), beta);
+    assert_eq!(decode::<Custom>(&encoded).unwrap(), beta);
 }
 
 #[test]
@@ -446,11 +464,11 @@ fn tagged_enum_rejects_unknown_tags_and_trailing_payload() {
     }
 
     assert_err_kind(
-        Command::rlp_decode(&mut alloy_rlp::encode((99u64,)).as_slice()),
+        decode::<Command>(alloy_rlp::encode((99u64,))),
         ErrorKind::Custom("unknown variant tag"),
     );
     assert_err_kind(
-        Command::rlp_decode(&mut alloy_rlp::encode((10u64, 1u8)).as_slice()),
+        decode::<Command>(alloy_rlp::encode((10u64, 1u8))),
         ErrorKind::ListLengthMismatch { expected: 0, got: 1 },
     );
 }
@@ -486,13 +504,10 @@ fn transparent_structs_encode_as_inner_field() {
         assert_eq!(encoded, alloy_rlp::encode(42u64));
     }
 
+    assert_eq!(decode::<Named>(alloy_rlp::encode(42u64)).unwrap(), Named { inner: 42 });
+    assert_eq!(decode::<Newtype>(alloy_rlp::encode(42u64)).unwrap(), Newtype(42));
     assert_eq!(
-        Named::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
-        Named { inner: 42 }
-    );
-    assert_eq!(Newtype::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(), Newtype(42));
-    assert_eq!(
-        WithSkip::rlp_decode(&mut alloy_rlp::encode(42u64).as_slice()).unwrap(),
+        decode::<WithSkip>(alloy_rlp::encode(42u64)).unwrap(),
         WithSkip { value: 42, marker: Marker }
     );
 }

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -412,6 +412,14 @@ fn flattened_trailing_options_do_not_consume_outer_fields() {
     let encoded = alloy_rlp::encode(&sentinel_then_some);
     assert_eq!(encoded, alloy_rlp::encode(&Flat { a: 1, maybe: 0, later: 2, tail: 3 }));
     assert_eq!(decode::<Outer>(&encoded).unwrap(), sentinel_then_some);
+
+    // `None, Some(2)` and `Some(0), Some(2)` have the same raw bytes because `0x80` is both the
+    // gap sentinel and the RLP encoding of `0u64`. The bounded rule reserves following fields and
+    // treats this shape as the gap form.
+    let ambiguous_some_zero_then_some =
+        Outer { inner: Inner { a: 1, maybe: Some(0), later: Some(2) }, tail: 3 };
+    assert_eq!(alloy_rlp::encode(&ambiguous_some_zero_then_some), encoded);
+    assert_eq!(decode::<Outer>(&encoded).unwrap(), sentinel_then_some);
 }
 
 #[test]
@@ -471,6 +479,26 @@ fn tagged_enum_rejects_unknown_tags_and_trailing_payload() {
         decode::<Command>(alloy_rlp::encode((10u64, 1u8))),
         ErrorKind::ListLengthMismatch { expected: 0, got: 1 },
     );
+}
+
+#[test]
+fn tagged_enum_unknown_tag_reports_tag_bytepos() {
+    #[derive(RlpDecodable, PartialEq, Debug)]
+    #[rlp(tagged)]
+    enum Command {
+        Start = 10,
+    }
+
+    #[derive(RlpDecodable, PartialEq, Debug)]
+    struct Envelope {
+        first: u8,
+        command: Command,
+    }
+
+    let encoded = alloy_rlp::encode((7u8, (99u64,)));
+    let err = decode::<Envelope>(&encoded).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Custom("unknown variant tag"));
+    assert_eq!(err.bytepos(), 3);
 }
 
 #[test]

--- a/crates/rlp/tests/ui.rs
+++ b/crates/rlp/tests/ui.rs
@@ -1,0 +1,7 @@
+//! Compile-fail coverage for derive diagnostics.
+
+#[test]
+fn derive_compile_failures() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/rlp/tests/ui.rs
+++ b/crates/rlp/tests/ui.rs
@@ -1,5 +1,6 @@
 //! Compile-fail coverage for derive diagnostics.
 
+#[cfg(feature = "derive")]
 #[test]
 fn derive_compile_failures() {
     let t = trybuild::TestCases::new();

--- a/crates/rlp/tests/ui/enum_without_tagged.rs
+++ b/crates/rlp/tests/ui/enum_without_tagged.rs
@@ -1,0 +1,8 @@
+use alloy_rlp::RlpEncodable;
+
+#[derive(RlpEncodable)]
+enum Bad {
+    A,
+}
+
+fn main() {}

--- a/crates/rlp/tests/ui/enum_without_tagged.stderr
+++ b/crates/rlp/tests/ui/enum_without_tagged.stderr
@@ -1,0 +1,7 @@
+error: RLP enum derives require `#[rlp(tagged)]`
+ --> tests/ui/enum_without_tagged.rs:4:1
+  |
+4 | / enum Bad {
+5 | |     A,
+6 | | }
+  | |_^

--- a/crates/rlp/tests/ui/flatten_option.rs
+++ b/crates/rlp/tests/ui/flatten_option.rs
@@ -1,0 +1,9 @@
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(RlpEncodable, RlpDecodable)]
+struct Bad {
+    #[rlp(flatten)]
+    value: Option<u8>,
+}
+
+fn main() {}

--- a/crates/rlp/tests/ui/flatten_option.stderr
+++ b/crates/rlp/tests/ui/flatten_option.stderr
@@ -1,0 +1,6 @@
+error: `#[rlp(flatten)]` cannot be used on `Option<T>` fields
+ --> tests/ui/flatten_option.rs:5:5
+  |
+5 | /     #[rlp(flatten)]
+6 | |     value: Option<u8>,
+  | |_____________________^

--- a/crates/rlp/tests/ui/missing_rlp_len_raw.rs
+++ b/crates/rlp/tests/ui/missing_rlp_len_raw.rs
@@ -1,0 +1,9 @@
+use alloy_rlp::{BufMut, Encoder, RlpEncodable};
+
+struct Bad;
+
+impl RlpEncodable for Bad {
+    fn rlp_encode<T: BufMut>(&self, _out: &mut Encoder<T>) {}
+}
+
+fn main() {}

--- a/crates/rlp/tests/ui/missing_rlp_len_raw.stderr
+++ b/crates/rlp/tests/ui/missing_rlp_len_raw.stderr
@@ -1,0 +1,7 @@
+error[E0046]: not all trait items implemented, missing: `rlp_len_raw`
+ --> tests/ui/missing_rlp_len_raw.rs:5:1
+  |
+5 | impl RlpEncodable for Bad {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `rlp_len_raw` in implementation
+  |
+  = help: implement the missing item: `fn rlp_len_raw(&self) -> usize { todo!() }`

--- a/crates/rlp/tests/ui/transparent_invalid_shape.rs
+++ b/crates/rlp/tests/ui/transparent_invalid_shape.rs
@@ -1,0 +1,10 @@
+use alloy_rlp::RlpEncodable;
+
+#[derive(RlpEncodable)]
+#[rlp(transparent)]
+struct Bad {
+    a: u8,
+    b: u8,
+}
+
+fn main() {}

--- a/crates/rlp/tests/ui/transparent_invalid_shape.stderr
+++ b/crates/rlp/tests/ui/transparent_invalid_shape.stderr
@@ -1,0 +1,5 @@
+error: `#[rlp(transparent)]` requires exactly one non-skipped field
+ --> tests/ui/transparent_invalid_shape.rs:5:8
+  |
+5 | struct Bad {
+  |        ^^^

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,9 +1,7 @@
 //! This example demonstrates how to encode and decode an enum using
 //! `alloy_rlp`.
 
-use alloy_rlp::{
-    encode, encode_list, Encoder, Error, ErrorKind, Header, RlpDecodable, RlpEncodable,
-};
+use alloy_rlp::{encode, BufMut, Decoder, Encoder, Error, ErrorKind, RlpDecodable, RlpEncodable};
 
 #[derive(Debug, PartialEq)]
 enum FooBar {
@@ -12,23 +10,21 @@ enum FooBar {
 }
 
 impl RlpEncodable for FooBar {
-    fn rlp_encode(&self, out: &mut Encoder<'_>) {
+    fn rlp_encode<T: BufMut>(&self, out: &mut Encoder<T>) {
         match self {
-            Self::Foo(x) => {
-                let enc: [&dyn RlpEncodable; 2] = [&0u8, x];
-                encode_list::<_, dyn RlpEncodable>(&enc, out);
-            }
-            Self::Bar(x, y) => {
-                let enc: [&dyn RlpEncodable; 3] = [&1u8, x, y];
-                encode_list::<_, dyn RlpEncodable>(&enc, out);
-            }
+            Self::Foo(x) => (0u8, *x).rlp_encode(out),
+            Self::Bar(x, y) => (1u8, *x, *y).rlp_encode(out),
         }
+    }
+
+    fn rlp_len_raw(&self) -> usize {
+        self.rlp_len()
     }
 }
 
-impl RlpDecodable for FooBar {
-    fn rlp_decode(data: &mut &[u8]) -> Result<Self, Error> {
-        let mut payload = Header::decode_bytes(data, true)?;
+impl<'de> RlpDecodable<'de> for FooBar {
+    fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self, Error> {
+        let mut payload = decoder.decode_payload(true)?;
         match u8::rlp_decode(&mut payload)? {
             0 => Ok(Self::Foo(u64::rlp_decode(&mut payload)?)),
             1 => Ok(Self::Bar(u16::rlp_decode(&mut payload)?, u64::rlp_decode(&mut payload)?)),
@@ -40,11 +36,11 @@ impl RlpDecodable for FooBar {
 fn main() {
     let val = FooBar::Foo(42);
     let out = encode(&val);
-    assert_eq!(FooBar::rlp_decode(&mut out.as_ref()), Ok(val));
+    assert_eq!(alloy_rlp::decode_exact::<FooBar>(&out), Ok(val));
 
     let val = FooBar::Bar(7, 42);
     let out = encode(&val);
-    assert_eq!(FooBar::rlp_decode(&mut out.as_ref()), Ok(val));
+    assert_eq!(alloy_rlp::decode_exact::<FooBar>(&out), Ok(val));
 
     println!("success!")
 }

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -25,11 +25,20 @@ impl RlpEncodable for FooBar {
 impl<'de> RlpDecodable<'de> for FooBar {
     fn rlp_decode(decoder: &mut Decoder<'de>) -> Result<Self, Error> {
         let mut payload = decoder.decode_payload(true)?;
-        match u8::rlp_decode(&mut payload)? {
-            0 => Ok(Self::Foo(u64::rlp_decode(&mut payload)?)),
-            1 => Ok(Self::Bar(u16::rlp_decode(&mut payload)?, u64::rlp_decode(&mut payload)?)),
-            _ => Err(ErrorKind::Custom("unknown type").into()),
+        let tag_bytepos = payload.bytepos();
+        let value = match u8::rlp_decode(&mut payload)? {
+            0 => Self::Foo(u64::rlp_decode(&mut payload)?),
+            1 => Self::Bar(u16::rlp_decode(&mut payload)?, u64::rlp_decode(&mut payload)?),
+            _ => return Err(payload.error_at(ErrorKind::Custom("unknown type"), tag_bytepos)),
+        };
+
+        if !payload.is_empty() {
+            return Err(
+                payload.error(ErrorKind::ListLengthMismatch { expected: 0, got: payload.len() })
+            );
         }
+
+        Ok(value)
     }
 }
 
@@ -41,6 +50,15 @@ fn main() {
     let val = FooBar::Bar(7, 42);
     let out = encode(&val);
     assert_eq!(alloy_rlp::decode_exact::<FooBar>(&out), Ok(val));
+
+    let unknown = encode((2u8,));
+    let err = alloy_rlp::decode_exact::<FooBar>(&unknown).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Custom("unknown type"));
+    assert_eq!(err.bytepos(), 1);
+
+    let trailing = encode((0u8, 42u64, 7u8));
+    let err = alloy_rlp::decode_exact::<FooBar>(&trailing).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::ListLengthMismatch { expected: 0, got: 1 });
 
     println!("success!")
 }


### PR DESCRIPTION
## Summary

This PR builds on #61 and completes the deferred Issue #14 API work:

- makes `RlpEncodable::rlp_len_raw` mandatory instead of keeping the compatibility default
- changes `RlpDecodable` to decode from `&mut Decoder<'de>` directly
- makes `Encoder` generic over `T: BufMut`
- propagates absolute byte positions through `Decoder`, public `Header::*_at` low-level paths, and payload validation errors
- adds a dedicated `trybuild` UI harness for derive compile-fail coverage
- defines a bounded raw-decoding rule for flattened trailing `Option<T>` fields using `MIN_RAW_ITEMS` plus raw tail reservations

For flattened trailing options, `0x80` is both the `None` gap sentinel and the valid RLP encoding of values like `0`, `false`, and empty strings. When another optional raw field follows, the bounded rule decodes that byte as the gap form; such `Some` values are only unambiguous when no later optional raw field is present.