### PR TITLE
Merge main into v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: {}
+
 on:
   push:
     branches: [main]
@@ -13,17 +15,21 @@ jobs:
     name: test ${{ matrix.rust }} ${{ matrix.flags }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         rust: ["stable", "beta", "nightly", "1.71"] # MSRV
         flags: ["--no-default-features", "", "--all-features"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: test
         run: cargo test --workspace ${{ matrix.flags }}
 
@@ -31,9 +37,13 @@ jobs:
     name: check WASM
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
       - name: check
@@ -43,11 +53,17 @@ jobs:
     name: feature checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2
+        with:
+          tool: cargo-hack
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: cargo hack
         run: cargo hack check --feature-powerset --depth 2 --all-targets
 
@@ -55,9 +71,13 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@clippy
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e7a32da269276b4d9cb3a0343133a168355ab751 # clippy
       - run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
@@ -66,9 +86,13 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: rust-docs
       - run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -79,12 +103,18 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: rustfmt
       - run: cargo fmt --all --check
 
   deny:
     uses: tempoxyz/ci/.github/workflows/deny.yml@main
+    permissions:
+      contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Alloy Contributors"]
@@ -36,8 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # workspace crates
-alloy-rlp = { version = "0.3.13", path = "crates/rlp", default-features = false }
-alloy-rlp-derive = { version = "0.3.13", path = "crates/rlp-derive", default-features = false }
+alloy-rlp = { version = "0.3.14", path = "crates/rlp", default-features = false }
+alloy-rlp-derive = { version = "0.3.14", path = "crates/rlp-derive", default-features = false }
 
 # macros
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Alloy Contributors"]
@@ -36,8 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # workspace crates
-alloy-rlp = { version = "0.3.14", path = "crates/rlp", default-features = false }
-alloy-rlp-derive = { version = "0.3.14", path = "crates/rlp-derive", default-features = false }
+alloy-rlp = { version = "0.3.15", path = "crates/rlp", default-features = false }
+alloy-rlp-derive = { version = "0.3.15", path = "crates/rlp-derive", default-features = false }
 
 # macros
 proc-macro2 = "1.0"

--- a/crates/rlp-derive/README.md
+++ b/crates/rlp-derive/README.md
@@ -9,3 +9,17 @@ similar to [`#[serde(default)]`](https://serde.rs/field-attrs.html#default)
 with the caveat that we use the `Default` value if the field deserialization
 fails, as we don't serialize field names and there is no way to tell if it is
 present or not.
+
+Optional trailing fields can be enabled with `#[rlp(trailing)]`.
+
+- `#[rlp(trailing)]` allows trailing `Option<_>` fields and uses `0x80` as the
+  placeholder for interior `None` values when a later optional field is present.
+- `#[rlp(trailing(no_gaps))]` omits every `None` optional field. Consumers must
+  ensure there are no gaps, meaning an optional field cannot be `None` if any
+  later optional field is `Some`.
+- `#[rlp(trailing(canonical))]` keeps the usual interior `0x80` placeholder but
+  requires trailing `None` values to be omitted rather than encoded as `0x80`.
+
+These options are contract-style APIs: the derive macros do not enforce the
+`no_gaps` or `canonical` invariants at runtime in release builds, so callers are
+responsible for constructing values that satisfy them.

--- a/crates/rlp-derive/src/de.rs
+++ b/crates/rlp-derive/src/de.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, is_optional, make_generics, option_inner_type, parse_struct,
+    parse_trailing_opts, TrailingOpts, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -10,30 +11,50 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
     let fields = body.fields.iter().enumerate();
 
-    let supports_trailing_opt = attributes_include(&ast.attrs, "trailing");
+    let trailing_opts = parse_trailing_opts(&ast.attrs);
 
     let mut encountered_opt_item = false;
     let mut decode_stmts = Vec::with_capacity(body.fields.len());
+    let mut canonical_assert_types = Vec::new();
     for (i, field) in fields {
         let is_opt = is_optional(field);
         if is_opt {
-            if !supports_trailing_opt {
+            if !trailing_opts.enabled {
                 let msg = "optional fields are disabled.\nAdd the `#[rlp(trailing)]` attribute to the struct in order to enable optional fields";
                 return Err(Error::new_spanned(field, msg));
             }
             encountered_opt_item = true;
+            if trailing_opts.canonical {
+                if let Some(inner_ty) = option_inner_type(field) {
+                    canonical_assert_types.push(inner_ty.clone());
+                }
+            }
         } else if encountered_opt_item && !attributes_include(&field.attrs, "default") {
             let msg =
                 "all the fields after the first optional field must be either optional or default";
             return Err(Error::new_spanned(field, msg));
         }
 
-        decode_stmts.push(decodable_field(i, field, is_opt));
+        decode_stmts.push(decodable_field(i, field, is_opt, trailing_opts));
     }
 
     let name = &ast.ident;
     let generics = make_generics(&ast.generics, quote!(alloy_rlp::Decodable));
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let strict_asserts = canonical_assert_types.iter().map(|ty| {
+        let msg = format!(
+            "trailing(canonical): `Option<{}>` is not supported because `{}` decodes successfully from 0x80 (the None placeholder). \
+             Use a type whose RLP encoding is never 0x80.",
+            quote!(#ty), quote!(#ty),
+        );
+        quote! {
+            debug_assert!(
+                <#ty as alloy_rlp::Decodable>::decode(&mut &[#EMPTY_STRING_CODE][..]).is_err(),
+                #msg,
+            );
+        }
+    });
 
     Ok(quote! {
         const _: () = {
@@ -42,6 +63,7 @@ pub(crate) fn impl_decodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
             impl #impl_generics alloy_rlp::Decodable for #name #ty_generics #where_clause {
                 #[inline]
                 fn decode(b: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                    #(#strict_asserts)*
                     let alloy_rlp::Header { list, payload_length } = alloy_rlp::Header::decode(b)?;
                     if !list {
                         return Err(alloy_rlp::Error::UnexpectedString);
@@ -97,23 +119,58 @@ pub(crate) fn impl_decodable_wrapper(ast: &syn::DeriveInput) -> Result<TokenStre
     })
 }
 
-fn decodable_field(index: usize, field: &syn::Field, is_opt: bool) -> TokenStream {
+fn decodable_field(
+    index: usize,
+    field: &syn::Field,
+    is_opt: bool,
+    trailing_opts: TrailingOpts,
+) -> TokenStream {
     let ident = field_ident(index, field);
 
     if attributes_include(&field.attrs, "default") {
         quote! { #ident: alloy_rlp::private::Default::default(), }
     } else if is_opt {
-        quote! {
-            #ident: if started_len - b.len() < payload_length {
-                if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
-                    alloy_rlp::Buf::advance(b, 1);
-                    None
-                } else {
+        if trailing_opts.no_gaps {
+            // no_gaps: no 0x80 sentinel logic; just decode if there's remaining payload
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
                     Some(alloy_rlp::Decodable::decode(b)?)
-                }
-            } else {
-                None
-            },
+                } else {
+                    None
+                },
+            }
+        } else if trailing_opts.canonical {
+            // canonical: 0x80 is only treated as a None placeholder if there is
+            // more payload remaining after consuming it. This ensures canonical encoding:
+            // trailing None fields must be omitted, not encoded as 0x80.
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
+                    if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE)
+                        && (started_len - b.len() + 1) < payload_length
+                    {
+                        alloy_rlp::Buf::advance(b, 1);
+                        None
+                    } else {
+                        Some(alloy_rlp::Decodable::decode(b)?)
+                    }
+                } else {
+                    None
+                },
+            }
+        } else {
+            // plain trailing: 0x80 always treated as None
+            quote! {
+                #ident: if started_len - b.len() < payload_length {
+                    if alloy_rlp::private::Option::map_or(b.first(), false, |b| *b == #EMPTY_STRING_CODE) {
+                        alloy_rlp::Buf::advance(b, 1);
+                        None
+                    } else {
+                        Some(alloy_rlp::Decodable::decode(b)?)
+                    }
+                } else {
+                    None
+                },
+            }
         }
     } else {
         quote! { #ident: alloy_rlp::Decodable::decode(b)?, }

--- a/crates/rlp-derive/src/en.rs
+++ b/crates/rlp-derive/src/en.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    attributes_include, field_ident, is_optional, make_generics, parse_struct, EMPTY_STRING_CODE,
+    attributes_include, field_ident, is_optional, make_generics, parse_struct, parse_trailing_opts,
+    TrailingOpts, EMPTY_STRING_CODE,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -16,28 +17,47 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
         .filter(|(_, field)| !attributes_include(&field.attrs, "skip"))
         .peekable();
 
-    let supports_trailing_opt = attributes_include(&ast.attrs, "trailing");
+    let trailing_opts = parse_trailing_opts(&ast.attrs);
 
     let mut encountered_opt_item = false;
     let mut length_exprs = Vec::with_capacity(body.fields.len());
     let mut encode_exprs = Vec::with_capacity(body.fields.len());
+    let mut opt_field_idents = Vec::new();
 
     while let Some((i, field)) = fields.next() {
         let is_opt = is_optional(field);
         if is_opt {
-            if !supports_trailing_opt {
+            if !trailing_opts.enabled {
                 let msg = "optional fields are disabled.\nAdd the `#[rlp(trailing)]` attribute to the struct in order to enable optional fields";
                 return Err(Error::new_spanned(field, msg));
             }
             encountered_opt_item = true;
+            opt_field_idents.push(field_ident(i, field));
         } else if encountered_opt_item {
             let msg = "all the fields after the first optional field must be optional";
             return Err(Error::new_spanned(field, msg));
         }
 
-        length_exprs.push(encodable_length(i, field, is_opt, fields.clone()));
-        encode_exprs.push(encodable_field(i, field, is_opt, fields.clone()));
+        length_exprs.push(encodable_length(i, field, is_opt, trailing_opts, fields.clone()));
+        encode_exprs.push(encodable_field(i, field, is_opt, trailing_opts, fields.clone()));
     }
+
+    let no_gaps_asserts = if trailing_opts.no_gaps && opt_field_idents.len() > 1 {
+        let mut asserts = Vec::new();
+        for window in opt_field_idents.windows(2) {
+            let cur = &window[0];
+            let next = &window[1];
+            asserts.push(quote! {
+                debug_assert!(
+                    self.#cur.is_some() || self.#next.is_none(),
+                    "no_gaps: gap detected — field after a None field is Some",
+                );
+            });
+        }
+        asserts
+    } else {
+        Vec::new()
+    };
 
     let name = &ast.ident;
     let generics = make_generics(&ast.generics, quote!(alloy_rlp::Encodable));
@@ -56,6 +76,7 @@ pub(crate) fn impl_encodable(ast: &syn::DeriveInput) -> Result<TokenStream> {
 
                 #[inline]
                 fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+                    #(#no_gaps_asserts)*
                     alloy_rlp::Header {
                         list: true,
                         payload_length: self._alloy_rlp_payload_length(),
@@ -162,19 +183,25 @@ fn encodable_length<'a>(
     index: usize,
     field: &syn::Field,
     is_opt: bool,
+    trailing_opts: TrailingOpts,
     mut remaining: Peekable<impl Iterator<Item = (usize, &'a syn::Field)>>,
 ) -> TokenStream {
     let ident = field_ident(index, field);
 
     if is_opt {
-        let default = if remaining.peek().is_some() {
-            let condition = remaining_opt_fields_some_condition(remaining);
-            quote! { (#condition) as usize }
+        if trailing_opts.no_gaps {
+            // no_gaps: no 0x80 placeholders for interior Nones
+            quote! { self.#ident.as_ref().map(|val| alloy_rlp::Encodable::length(val)).unwrap_or(0) }
         } else {
-            quote! { 0 }
-        };
+            let default = if remaining.peek().is_some() {
+                let condition = remaining_opt_fields_some_condition(remaining);
+                quote! { (#condition) as usize }
+            } else {
+                quote! { 0 }
+            };
 
-        quote! { self.#ident.as_ref().map(|val| alloy_rlp::Encodable::length(val)).unwrap_or(#default) }
+            quote! { self.#ident.as_ref().map(|val| alloy_rlp::Encodable::length(val)).unwrap_or(#default) }
+        }
     } else {
         quote! { alloy_rlp::Encodable::length(&self.#ident) }
     }
@@ -184,6 +211,7 @@ fn encodable_field<'a>(
     index: usize,
     field: &syn::Field,
     is_opt: bool,
+    trailing_opts: TrailingOpts,
     mut remaining: Peekable<impl Iterator<Item = (usize, &'a syn::Field)>>,
 ) -> TokenStream {
     let ident = field_ident(index, field);
@@ -195,7 +223,10 @@ fn encodable_field<'a>(
             }
         };
 
-        if remaining.peek().is_some() {
+        if trailing_opts.no_gaps {
+            // no_gaps: just encode if Some, skip if None (no placeholder)
+            quote! { #if_some_encode }
+        } else if remaining.peek().is_some() {
             let condition = remaining_opt_fields_some_condition(remaining);
             quote! {
                 #if_some_encode

--- a/crates/rlp-derive/src/utils.rs
+++ b/crates/rlp-derive/src/utils.rs
@@ -5,6 +5,40 @@ use syn::{
     TypePath,
 };
 
+#[derive(Default, Clone, Copy)]
+pub(crate) struct TrailingOpts {
+    pub enabled: bool,
+    pub no_gaps: bool,
+    pub canonical: bool,
+}
+
+pub(crate) fn parse_trailing_opts(attrs: &[Attribute]) -> TrailingOpts {
+    let mut opts = TrailingOpts::default();
+    for attr in attrs {
+        if attr.path().is_ident("rlp") {
+            if let Meta::List(meta) = &attr.meta {
+                let _ = meta.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("trailing") {
+                        opts.enabled = true;
+                        if meta.input.peek(syn::token::Paren) {
+                            meta.parse_nested_meta(|inner| {
+                                if inner.path.is_ident("no_gaps") {
+                                    opts.no_gaps = true;
+                                } else if inner.path.is_ident("canonical") {
+                                    opts.canonical = true;
+                                }
+                                Ok(())
+                            })?;
+                        }
+                    }
+                    Ok(())
+                });
+            }
+        }
+    }
+    opts
+}
+
 pub(crate) const EMPTY_STRING_CODE: u8 = 0x80;
 
 pub(crate) fn parse_struct<'a>(
@@ -42,14 +76,28 @@ pub(crate) fn attributes_include(attrs: &[Attribute], attr_name: &str) -> bool {
 }
 
 pub(crate) fn is_optional(field: &Field) -> bool {
+    option_inner_type(field).is_some()
+}
+
+/// Extracts the inner type `T` from an `Option<T>` field, or returns `None` if the field is not
+/// an `Option`.
+pub(crate) fn option_inner_type(field: &Field) -> Option<&syn::Type> {
     if let Type::Path(TypePath { qself, path }) = &field.ty {
-        qself.is_none()
+        if qself.is_none()
             && path.leading_colon.is_none()
             && path.segments.len() == 1
             && path.segments.first().unwrap().ident == "Option"
-    } else {
-        false
+        {
+            if let syn::PathArguments::AngleBracketed(args) =
+                &path.segments.first().unwrap().arguments
+            {
+                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                    return Some(inner);
+                }
+            }
+        }
     }
+    None
 }
 
 pub(crate) fn field_ident(index: usize, field: &syn::Field) -> TokenStream {

--- a/crates/rlp/README.md
+++ b/crates/rlp/README.md
@@ -13,6 +13,24 @@ We strongly recommend deriving RLP traits via the `RlpEncodable` and
 
 Trait methods can then be accessed via the `Encodable` and `Decodable` traits.
 
+## Trailing Optional Fields
+
+The derive macros support trailing `Option<_>` fields via `#[rlp(trailing)]`.
+This enables the common RLP pattern where optional fields may be omitted from the
+end of a list.
+
+Two stricter variants are also available:
+
+- `#[rlp(trailing(no_gaps))]` omits every `None` optional field, including
+  interior ones. This only works if consumers construct values without gaps,
+  meaning no later optional field may be `Some` after an earlier one is `None`.
+- `#[rlp(trailing(canonical))]` preserves interior `None` placeholders when a
+  later optional field is present, but trailing `None` values must still be
+  omitted to remain canonical.
+
+These modes do not perform runtime validation in release builds. They describe
+encoding invariants that callers must uphold when constructing values.
+
 ## Example
 
 ```rust

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -1,6 +1,11 @@
 use crate::{Error, Header, Result};
 use bytes::{Bytes, BytesMut};
-use core::marker::{PhantomData, PhantomPinned};
+use core::{
+    marker::{PhantomData, PhantomPinned},
+    num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize},
+};
+
+const NON_ZERO_INTEGER_ERROR: &str = "non-zero integer cannot be zero";
 
 /// A type that can be decoded from an RLP blob.
 pub trait Decodable: Sized {
@@ -77,6 +82,28 @@ macro_rules! decode_integer {
 }
 
 decode_integer!(u8, u16, u32, u64, usize, u128);
+
+macro_rules! decode_nonzero_integer {
+    ($($t:ty => $inner:ty),+ $(,)?) => {$(
+        impl Decodable for $t {
+            #[inline]
+            fn decode(buf: &mut &[u8]) -> Result<Self> {
+                <$inner>::decode(buf).and_then(|value| {
+                    <$t>::new(value).ok_or(Error::Custom(NON_ZERO_INTEGER_ERROR))
+                })
+            }
+        }
+    )+};
+}
+
+decode_nonzero_integer! {
+    NonZeroU8 => u8,
+    NonZeroU16 => u16,
+    NonZeroU32 => u32,
+    NonZeroU64 => u64,
+    NonZeroUsize => usize,
+    NonZeroU128 => u128,
+}
 
 impl Decodable for Bytes {
     #[inline]
@@ -236,7 +263,10 @@ pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N]> {
 mod tests {
     use super::*;
     use crate::{encode, Encodable};
-    use core::fmt::Debug;
+    use core::{
+        fmt::Debug,
+        num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize},
+    };
     use hex_literal::hex;
 
     #[allow(unused_imports)]
@@ -321,6 +351,24 @@ mod tests {
                 &hex!("A101000000000000000000000000000000000000008B000000000000000000000000")[..],
             ),
         ])
+    }
+
+    #[test]
+    fn rlp_nonzero_uints() {
+        check_decode([(Ok(NonZeroU8::new(9).unwrap()), &hex!("09")[..])]);
+        check_decode([(Ok(NonZeroU16::new(0x0505).unwrap()), &hex!("820505")[..])]);
+        check_decode([(Ok(NonZeroU32::new(0xCE0505).unwrap()), &hex!("83CE0505")[..])]);
+        check_decode([(Ok(NonZeroU64::new(0xCE05050505).unwrap()), &hex!("85CE05050505")[..])]);
+        check_decode([(Ok(NonZeroUsize::new(0x80).unwrap()), &hex!("8180")[..])]);
+        check_decode([(
+            Ok(NonZeroU128::new(0x10203E405060708090A0B0C0D0E0F2).unwrap()),
+            &hex!("8f10203e405060708090a0b0c0d0e0f2")[..],
+        )]);
+        check_decode::<NonZeroU8, _>([(
+            Err(Error::Custom(NON_ZERO_INTEGER_ERROR)),
+            &hex!("80")[..],
+        )]);
+        check_decode::<NonZeroU8, _>([(Err(Error::LeadingZero), &hex!("00")[..])]);
     }
 
     #[test]

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -126,15 +126,25 @@ impl Decodable for alloc::string::String {
     }
 }
 
+/// Decodes an RLP list and appends each item to the provided vector.
+///
+/// # Errors
+///
+/// Returns an error if the input is not a valid RLP list or any item fails to decode.
+#[inline]
+pub fn decode_append<T: Decodable>(buf: &mut &[u8], out: &mut alloc::vec::Vec<T>) -> Result<()> {
+    let mut payload = Header::decode_bytes(buf, true)?;
+    while !payload.is_empty() {
+        out.push(T::decode(&mut payload)?);
+    }
+    Ok(())
+}
+
 impl<T: Decodable> Decodable for alloc::vec::Vec<T> {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self> {
-        let mut bytes = Header::decode_bytes(buf, true)?;
         let mut vec = Self::new();
-        let payload_view = &mut bytes;
-        while !payload_view.is_empty() {
-            vec.push(T::decode(payload_view)?);
-        }
+        decode_append(buf, &mut vec)?;
         Ok(vec)
     }
 }
@@ -377,6 +387,20 @@ mod tests {
             (Ok(vec![]), &hex!("C0")[..]),
             (Ok(vec![0xBBCCB5_u64, 0xFFC0B5_u64]), &hex!("C883BBCCB583FFC0B5")[..]),
         ])
+    }
+
+    #[test]
+    fn rlp_decode_append_appends_to_existing_vec() {
+        let mut input = &hex!("C883BBCCB583FFC0B5")[..];
+        let mut values = Vec::with_capacity(4);
+        values.push(0x01);
+        let capacity = values.capacity();
+
+        decode_append::<u64>(&mut input, &mut values).unwrap();
+
+        assert!(input.is_empty());
+        assert_eq!(values, vec![0x01, 0xBBCCB5_u64, 0xFFC0B5_u64]);
+        assert_eq!(values.capacity(), capacity);
     }
 
     #[cfg(feature = "std")]

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -3,6 +3,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use core::{
     borrow::Borrow,
     marker::{PhantomData, PhantomPinned},
+    num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize},
 };
 
 #[allow(unused_imports)]
@@ -193,6 +194,33 @@ macro_rules! uint_impl {
 }
 
 uint_impl!(u8, u16, u32, u64, usize, u128);
+
+macro_rules! nonzero_uint_impl {
+    ($($t:ty => $inner:ty),+ $(,)?) => {$(
+        impl Encodable for $t {
+            #[inline]
+            fn length(&self) -> usize {
+                self.get().length()
+            }
+
+            #[inline]
+            fn encode(&self, out: &mut dyn BufMut) {
+                self.get().encode(out);
+            }
+        }
+
+        impl_max_encoded_len!($t, <$inner as MaxEncodedLenAssoc>::LEN);
+    )+};
+}
+
+nonzero_uint_impl! {
+    NonZeroU8 => u8,
+    NonZeroU16 => u16,
+    NonZeroU32 => u32,
+    NonZeroU64 => u64,
+    NonZeroUsize => usize,
+    NonZeroU128 => u128,
+}
 
 impl<T: Encodable> Encodable for Vec<T> {
     #[inline]
@@ -386,6 +414,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
     use hex_literal::hex;
 
     fn encoded_list<T: Encodable + Clone>(t: &[T]) -> BytesMut {
@@ -488,6 +517,22 @@ mod tests {
         uint_rlp_test!(u128_fixtures());
         // #[cfg(feature = "ethnum")]
         // uint_rlp_test!(u256_fixtures());
+    }
+
+    #[test]
+    fn rlp_nonzero_uints() {
+        uint_rlp_test!([(NonZeroU8::new(1).unwrap(), &hex!("01")[..])]);
+        uint_rlp_test!([(NonZeroU16::new(0x400).unwrap(), &hex!("820400")[..])]);
+        uint_rlp_test!([(NonZeroU32::new(0xFFCCB5).unwrap(), &hex!("83ffccb5")[..])]);
+        uint_rlp_test!([(
+            NonZeroU64::new(0xFFCCB5DDFFEE1483).unwrap(),
+            &hex!("88ffccb5ddffee1483")[..]
+        )]);
+        uint_rlp_test!([(NonZeroUsize::new(0x80).unwrap(), &hex!("8180")[..])]);
+        uint_rlp_test!([(
+            NonZeroU128::new(0x10203E405060708090A0B0C0D0E0F2).unwrap(),
+            &hex!("8f10203e405060708090a0b0c0d0e0f2")[..],
+        )]);
     }
 
     /*

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate alloc;
 
 mod decode;
-pub use decode::{decode_exact, Decodable, Rlp};
+pub use decode::{decode_append, decode_exact, Decodable, Rlp};
 
 mod error;
 pub use error::{Error, Result};

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -61,6 +61,112 @@ const fn opt() {
     }
 }
 
+#[test]
+fn trailing_no_gaps() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing(no_gaps))]
+    struct NoGaps {
+        required: u64,
+        a: Option<[u8; 32]>,
+        b: Option<[u8; 32]>,
+    }
+
+    let h1 = [1u8; 32];
+    let h2 = [2u8; 32];
+
+    // Roundtrip with all fields present.
+    let val = NoGaps { required: 1, a: Some(h1), b: Some(h2) };
+    let mut buf = Vec::new();
+    val.encode(&mut buf);
+    let decoded = NoGaps::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Roundtrip with all optional fields absent.
+    let val = NoGaps { required: 1, a: None, b: None };
+    buf.clear();
+    val.encode(&mut buf);
+    assert_eq!(buf, vec![0xc1, 0x01]);
+    let decoded = NoGaps::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Roundtrip with first present, second absent.
+    let val = NoGaps { required: 1, a: Some(h1), b: None };
+    buf.clear();
+    val.encode(&mut buf);
+    let decoded = NoGaps::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // With no_gaps, 0x80 in the payload is decoded as Some (attempting to decode the inner
+    // type), not as a None placeholder. For [u8; 32] this fails since 0x80 is too short.
+    let non_canonical = vec![0xc2, 0x01, 0x80];
+    assert!(NoGaps::decode(&mut non_canonical.as_slice()).is_err());
+}
+
+#[test]
+fn trailing_canonical() {
+    #[derive(RlpEncodable, RlpDecodable, PartialEq, Debug)]
+    #[rlp(trailing(canonical))]
+    struct Canonical {
+        required: u64,
+        a: Option<[u8; 32]>,
+        b: Option<[u8; 32]>,
+    }
+
+    let h1 = [1u8; 32];
+    let h2 = [2u8; 32];
+
+    // Roundtrip with all fields present.
+    let val = Canonical { required: 1, a: Some(h1), b: Some(h2) };
+    let mut buf = Vec::new();
+    val.encode(&mut buf);
+    let decoded = Canonical::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Roundtrip with all optional fields absent.
+    let val = Canonical { required: 1, a: None, b: None };
+    buf.clear();
+    val.encode(&mut buf);
+    assert_eq!(buf, vec![0xc1, 0x01]);
+    let decoded = Canonical::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Roundtrip with first present, second absent.
+    let val = Canonical { required: 1, a: Some(h1), b: None };
+    buf.clear();
+    val.encode(&mut buf);
+    let decoded = Canonical::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Roundtrip with first absent, second present — uses 0x80 placeholder for `a`.
+    let val = Canonical { required: 1, a: None, b: Some(h2) };
+    buf.clear();
+    val.encode(&mut buf);
+    assert_eq!(buf[1], 0x01); // required
+    assert_eq!(buf[2], 0x80); // None placeholder
+    let decoded = Canonical::decode(&mut buf.as_slice()).unwrap();
+    assert_eq!(val, decoded);
+
+    // Non-canonical: trailing 0x80 is decoded as Some, which fails for [u8; 32].
+    let non_canonical = vec![0xc2, 0x01, 0x80];
+    assert!(Canonical::decode(&mut non_canonical.as_slice()).is_err());
+}
+
+/// Test that trailing options compile with generics.
+#[test]
+const fn trailing_opts_compiles() {
+    #[derive(RlpEncodable, RlpDecodable)]
+    #[rlp(trailing)]
+    struct PlainTrailing<T>(Option<Vec<T>>);
+
+    #[derive(RlpEncodable, RlpDecodable)]
+    #[rlp(trailing(no_gaps))]
+    struct NoGapsTrailing<T>(Option<Vec<T>>);
+
+    #[derive(RlpEncodable, RlpDecodable)]
+    #[rlp(trailing(canonical))]
+    struct CanonicalTrailing<T>(Option<Vec<T>>);
+}
+
 /// Test that multiple attributes can be combined in a single `#[rlp(...)]`.
 /// See <https://github.com/alloy-rs/rlp/issues/9>
 #[test]


### PR DESCRIPTION
## Summary

Merge `main` into `v1` after #61/#62 landed so the v1 branch has the current main-line CI/workspace updates and RLP follow-ups.

Resolved conflicts by preserving the v1 Issue #14 API work while bringing over main additions:

- CI/dependabot/workspace metadata updates from `main`
- `#[rlp(trailing(no_gaps))]` and `#[rlp(trailing(canonical))]` derive support, adapted to `RlpEncodable`/`RlpDecodable<'de>` and raw flattening
- NonZero integer encode/decode impls, adapted to byte-position-aware errors
- `decode_append`, adapted to the `Decoder<'de>` API
- README and derive tests from `main`, updated for the v1 APIs

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p alloy-rlp --all-features`
- `cargo test -p alloy-rlp-derive --all-features`
- `cargo test -p alloy-rlp --no-default-features --test ui`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
